### PR TITLE
feat: Add fine-grained permission control and category resolution times OP-2804

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The module supports both simple and enhanced category configurations:
 #### Enhanced Format with Auto-Generated Permission IDs
 
 > **Note:** `permissions` values are permission-type strings (`restricted_read`, `read`, `create`, `update`, `delete`), not numeric right IDs. The system generates numeric IDs automatically.
-```json
+```jsonc
 {
   "default_grievance_type": "uncategorized",
   "grievance_flags": [
@@ -132,7 +132,7 @@ Resolution times are determined in the following order:
 4. Default value `5,0` (5 days, 0 hours)
 
 ##### Example Configuration
-```json
+```jsonc
 {
   "resolution_times": "5,0",  // Global default: 5 days
   "grievance_types": [
@@ -181,7 +181,7 @@ The `visible_fields` feature controls field visibility for users with `restricte
    - Non-visible fields return `[Restricted]` for text fields or `null` for other types
 
 4. **Example Inheritance**:
-```json
+```jsonc
 {
   "name": "complaint",
   "visible_fields": ["id", "status", "category", "priority", "date_created"],
@@ -218,7 +218,7 @@ Flags are single-level configurations only and do NOT support hierarchical/neste
 ```
 
 #### Enhanced Format with Permissions
-```json
+```jsonc
 {
   "grievance_flags": [
     "public",

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ It is dedicated to be deployed as a module of [openimis-be_py](https://github.co
 
 ### Basic Configuration
 
-* `default_grievance_type`: The default category assigned to tickets when no category is specified. 
+* `default_grievance_type`: The category name assigned to tickets when no category is specified. This should be a simple string value. If this category doesn't exist in `grievance_types`, it will be auto-added with `['read', 'update']` permissions.
 (default: `'uncategorized'`)
-Note: This type is automatically added to the grievance_types list with `['read', 'update']` permissions if not already present.
 
 * `resolution_times`: time to resolution in form of CRON timedelta: {days},{hours} where days are values between <0, 99) and hours are between 0 and 24. 
 (default: `5,0`)
@@ -134,9 +133,6 @@ Resolution times are determined in the following order:
 ```json
 {
   "resolution_times": "5,0",  // Global default: 5 days
-  "default_resolution": {     // Legacy configuration (still supported)
-    "feedback": "7,0"
-  },
   "grievance_types": [
     {
       "name": "complaint",
@@ -210,7 +206,7 @@ The `visible_fields` feature controls field visibility for users with `restricte
 
 ### Flags Configuration
 
-Similarly, flags support both simple and enhanced formats:
+Flags are single-level configurations only and do NOT support hierarchical/nested structures. Unlike categories (`grievance_types`) which support parent-child relationships with permission inheritance, flags are always flat.
 
 #### Simple Format
 ```json

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ It is dedicated to be deployed as a module of [openimis-be_py](https://github.co
 - **Grievance Management**: Create, update, and track grievances
 - **Comments System**: Add comments and resolutions to grievance
 - **Configurable Categories and Flags**: Define custom grievance types and flags
-- **Rights-Based Access Control**: Fine-grained permissions for categories and flags
-- **Hierarchical Categories**: Support for multi-level category structures
+- **Automatic Rights Generation**: Auto-generate rights based on category/flag permissions
+- **Restricted View Access**: Three-tier access levels (restricted/read/full) with automatic data filtering
+- **Hierarchical Categories**: Support for multi-level category structures with permission inheritance
 - **Priority Management**: Automatic priority assignment based on category/flag configuration
 - **Resolution Tracking**: Configure resolution times by category
 
@@ -36,7 +37,7 @@ The module supports both simple and enhanced category configurations:
 }
 ```
 
-#### Enhanced Format with Permissions and Resolution Times
+#### Enhanced Format with Auto-Generated Permission IDs
 ```json
 {
   "grievance_flags": [
@@ -44,7 +45,7 @@ The module supports both simple and enhanced category configurations:
     {
       "name": "sensitive",
       "priority": "Critical",
-      "permissions":["127001", "127002"]
+      "permissions": ["restricted_read", "read", "create"]
     }
   ],
   "grievance_types": [
@@ -52,24 +53,69 @@ The module supports both simple and enhanced category configurations:
     {
       "name": "complaint",
       "priority": "High",
-      "permissions": ["127001", "127002"],  // Grants all access to users with either permission
+      "permissions": ["restricted_read", "read", "create", "update"],
+      "visible_fields": ["id", "status", "category", "priority", "date_created"],
       "default_flags": ["urgent"],
       "resolution_times": "3,0",  // 3 days, 0 hours
       "children": [
         {
-          "name": "service_complaint",
-          "permissions": ["127003"],  // Child can override with its own permissions
-          "resolution_times": "2,12"  // Overrides parent's resolution time
+          "name": "vbg_complaint",
+          "permissions": ["restricted_read", "read", "create"],
+          "visible_fields": ["id", "status", "category"],  // More restrictive than parent
+          "resolution_times": "2,12",  // Overrides parent's resolution time
+          "default_flags": ["confidential"]
         },
         {
           "name": "general_complaint"
-          // Inherits parent's resolution_times (3,0) and permissions
+          // Inherits parent's permissions and visible_fields
         }
       ]
     }
   ]
 }
 ```
+
+##### Permission ID Auto-Generation
+The grievance module automatically generates permission IDs using Django's auth_permission table:
+
+1. **ID Range Convention**:
+   - Static permissions: 127000-127099 (hardcoded module permissions)
+   - Dynamic permissions: 127100-127999 (auto-generated for categories/flags)
+
+2. **Auto-Generated ID Pattern**:
+   Permission IDs are automatically assigned following a suffix pattern:
+   - IDs ending in `0` - read permission (for gql_query_*)
+   - IDs ending in `1` - create permission (for gql_mutation_create_*)
+   - IDs ending in `2` - update permission (for gql_mutation_update_*)
+   - IDs ending in `3` - delete permission (for gql_mutation_delete_*)
+   - IDs ending in `4` - restricted_read permission
+
+3. **Permission Types**:
+   - `"restricted_read"` - Limited view access
+   - `"read"` - Full read access
+   - `"create"` - Create/write access
+   - `"update"` - Update/modify access
+   - `"delete"` - Delete access
+
+4. **Persistence**:
+   - Permissions are stored in Django's `auth_permission` table
+   - Once assigned, an ID remains stable even if configuration changes
+   - Permissions can be managed through Django admin interface
+   - Deleted permissions free up their IDs for reuse
+
+3. **Access Levels** (based on user's rights):
+   - **Restricted Access** (`restricted_read` right): 
+     - If `visible_fields` is configured: Users see only fields listed in `visible_fields`
+     - If `visible_fields` is not configured: Users see only basic info (id, status, dates, category, priority)
+     - Non-visible fields show as "[Restricted]" for text fields or null for other types
+     - Can only filter queries on visible fields
+   - **Read Access** (`read` right): 
+     - Users see all ticket information including descriptions and resolutions
+     - Can filter on all fields
+     - Cannot modify tickets
+   - **Full Access** (`create`/`update` rights): 
+     - Users can view and modify tickets
+     - Can create new tickets in categories where they have `create` permission
 
 ##### Resolution Times Priority
 Resolution times are determined in the following order:
@@ -103,6 +149,59 @@ Resolution times are determined in the following order:
   ]
 }
 
+#### Visible Fields Configuration
+
+The `visible_fields` feature controls field visibility for users with `restricted_read` permission:
+
+```json
+{
+  "name": "complaint",
+  "visible_fields": ["id", "status", "category", "priority", "date_created"],
+  "permissions": ["restricted_read", "read", "create"]
+}
+```
+
+**Key Features:**
+
+1. **Automatic Permission Requirements**: When `visible_fields` is defined, the system automatically adds `restricted_read` and `read` permissions if not already present.
+
+2. **Inheritance with Security Boundaries**: 
+   - Child categories inherit parent's `visible_fields` by default
+   - **Security Boundary**: Children can only make fields MORE restrictive, never less
+   - A child cannot expose fields that the parent has hidden
+   - This ensures security boundaries are maintained through the category hierarchy
+
+3. **Field Visibility Rules**:
+   - Users with `restricted_read`: See only fields in `visible_fields` list
+   - Users with `read` or higher: See all fields
+   - Non-visible fields return `[Restricted]` for text fields or `null` for other types
+
+4. **Example Inheritance**:
+```json
+{
+  "name": "complaint",
+  "visible_fields": ["id", "status", "category", "priority", "date_created"],
+  "children": [
+    {
+      "name": "vbg_complaint",
+      "visible_fields": ["id", "status"]  // ✓ Valid - subset of parent
+    },
+    {
+      "name": "fraud_complaint",
+      "visible_fields": ["id", "status", "title"]  // ✗ Invalid - "title" not in parent
+      // System will automatically remove "title" and log a warning
+    }
+  ]
+}
+```
+
+5. **Default Behavior**: If `visible_fields` is not configured, restricted users see a default set of basic fields: `id`, `status`, `category`, `priority`, `date_created`.
+
+6. **Interaction with Default Flags**: 
+   - Categories cannot reduce security set by their default flags
+   - If a category has `default_flags: ["confidential"]` and the confidential flag restricts certain fields, the category's `visible_fields` must respect those restrictions
+   - This prevents accidental exposure of sensitive information through misconfiguration
+
 ### Flags Configuration
 
 Similarly, flags support both simple and enhanced formats:
@@ -122,7 +221,7 @@ Similarly, flags support both simple and enhanced formats:
     {
       "name": "sensitive",
       "priority": "Critical",
-      "permissions": ["127004", "127005"]  // Grants all access
+      "permissions": ["read", "create"]  // Auto-generates permission IDs
     }
   ]
 }
@@ -157,10 +256,122 @@ The `grievance_config` query returns:
 
 ## Access Control Features
 
-1. **Category-Based Filtering**: Users only see grievances in categories they have permission to view
-2. **Flag-Based Filtering**: Grievances with restricted flags are hidden from unauthorized users
-3. **Hierarchical Permissions**: 
+1. **Two-Tier Permission System**:
+   - **Tier 1**: General ticket permissions (required for ALL ticket operations)
+     - 127000: Query tickets
+     - 127001: Create tickets
+     - 127002: Update tickets
+     - 127003: Delete tickets
+   - **Tier 2**: Category/flag-specific permissions (additional requirements for restricted categories)
+
+2. **Role Composition Pattern**:
+   The system supports hierarchical role composition for clean permission management:
+   ```
+   GRIEVANCE_VIEWER (Base role)
+   ├── General ticket query permissions
+   └── Access to unrestricted categories
+   
+   COMPLAINT_VIEWER (Category role) 
+   ├── Requires: GRIEVANCE_VIEWER
+   └── Complaint category view permissions
+   
+   GBV_SPECIALIST (Specialized role)
+   ├── Requires: GRIEVANCE_VIEWER + COMPLAINT_VIEWER
+   └── VBG-specific permissions
+   ```
+   
+   Users are assigned multiple roles to compose their complete permission set.
+
+3. **Category-Based Filtering**: Users only see grievances in categories they have permission to view
+
+4. **Flag-Based Filtering**: Grievances with restricted flags are hidden from unauthorized users
+
+5. **Hierarchical Permissions**: 
    - Children inherit parent permissions by default
    - Children can override with more restrictive permissions
    - Users see only accessible parts of the hierarchy
-4. **Create/Update Validation**: System validates permissions before allowing grievance operations
+
+6. **Create/Update Validation**: System validates permissions before allowing grievance operations
+
+7. **Mixed Flag Handling**: When a grievance has multiple flags:
+   - Flags without restrictions are ignored in access calculations
+   - Access level is determined by the most restrictive flag that has permissions defined
+
+## Security Implementation
+
+Fine-grained security is enforced at the Django model level by overriding the `get_queryset` method. This ensures that security applies consistently across all endpoint technologies (GraphQL, FHIR, REST, etc.).
+
+### Model-Level Security
+
+Security filtering is implemented in the models themselves:
+
+```python
+# grievance_social_protection/models.py
+
+class Ticket(HistoryBusinessModel):
+    @classmethod
+    def get_queryset(cls, queryset, user):
+        queryset = cls.filter_queryset(queryset)
+        # GraphQL calls with an info object while Rest calls with the user itself
+        if isinstance(user, ResolveInfo):
+            user = user.context.user
+        if settings.ROW_SECURITY and user.is_anonymous:
+            return queryset.filter(id=None)
+        if settings.ROW_SECURITY:
+            # Apply category and flag permission filtering
+            from .access_control import GrievanceAccessControl
+            queryset = GrievanceAccessControl.filter_ticket_queryset(queryset, user)
+        return queryset
+```
+
+### Field-Level Access Control
+
+While queryset filtering happens at the model level, field-level access control (showing "[Restricted]" for sensitive fields) is implemented in the GraphQL type resolvers to provide granular control over field visibility based on the user's access level
+
+## Permission Management
+
+### Auto-Generated Permissions
+
+The module uses Django's `auth_permission` table to store and manage permissions:
+
+1. **Automatic Creation**: On module startup, permissions are automatically created in the `auth_permission` table based on your configuration
+2. **Stable IDs**: Once created, permission IDs remain stable even if configuration changes
+3. **Django Admin Management**: Permissions can be viewed and managed through Django's admin interface
+4. **ID Reuse**: Deleted permissions free up their IDs for potential reuse following the suffix pattern
+
+### Permission Lifecycle
+
+1. **Creation**:
+   - Configure categories/flags with permission requirements in ModuleConfiguration
+   - On startup, system checks if permissions exist in `auth_permission`
+   - New permissions are created with auto-generated IDs following the suffix pattern
+   - Existing permissions retain their IDs
+
+2. **Updates**:
+   - Configuration changes don't affect existing permission IDs
+   - New permissions in configuration create new entries
+   - Removed permissions from configuration remain in `auth_permission` until manually deleted
+
+3. **Deletion**:
+   - Permissions must be explicitly deleted through Django admin
+   - Deleting a permission frees its ID for reuse
+   - Roles referencing deleted permissions lose that access
+
+### Managing Permissions
+
+Use the provided management command to view and manage permissions:
+
+```bash
+# List all grievance permissions
+python manage.py manage_grievance_permissions list
+
+# Export permission mapping for backup
+python manage.py manage_grievance_permissions export --format=json > permissions_backup.json
+
+# Find and remove orphaned permissions
+python manage.py manage_grievance_permissions cleanup --dry-run
+python manage.py manage_grievance_permissions cleanup
+
+# Sync permissions with current configuration
+python manage.py manage_grievance_permissions sync
+```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The module supports both simple and enhanced category configurations:
 ```
 
 #### Enhanced Format with Auto-Generated Permission IDs
+
+> **Note:** `permissions` values are permission-type strings (`restricted_read`, `read`, `create`, `update`, `delete`), not numeric right IDs. The system generates numeric IDs automatically.
 ```json
 {
   "default_grievance_type": "uncategorized",

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The `visible_fields` feature controls field visibility for users with `restricte
     {
       "name": "fraud_complaint",
       "visible_fields": ["id", "status", "title"]  // ✗ Invalid - "title" not in parent
-      // System will automatically remove "title" and log a warning
+      // System will raise a ValueError until this is corrected
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Value - time to resolution in form of CRON timedelta: `{days},{hours}` where day
 (default: `{Default: '5,0'}`)
 Note: If for given type of the grievance time is not provided then default value is used from `resolution_times`.
 
+### Category Separator
+
+The system uses ` > ` (space-greater than-space) as the hierarchy separator in category full names. For example, a child category `Missing Documents` under parent `Enrollment` has the full name `Enrollment > Missing Documents`. This separator is used universally across the backend (internal keys, database storage, permission names) and frontend (display, Cascader values).
+
+**Important:** Category names must not contain ` > ` as this would break hierarchy parsing.
+
+The separator is defined as `CATEGORY_SEPARATOR` in `apps.py` and imported where needed.
+
 ### Categories Configuration
 
 The module supports both simple and enhanced category configurations:
@@ -253,7 +261,8 @@ The `grievance_config` query returns:
 - `grievance_types`: Flat list of accessible categories
 - `grievance_flags`: List of accessible flags
 - `grievance_channels`: Available channels
-- `grievance_categories_hierarchical`: Hierarchical category structure
+- `grievance_categories_hierarchical`: Hierarchical category structure (recursive `GrievanceCategoryGQLType`; depth depends on client query)
+- `grievance_categories_json`: Full category hierarchy as JSON (no depth limitation)
 - `grievance_flags_detailed`: Detailed flag information with permissions
 - `accessible_categories`: Categories user can create grievances in
 - `accessible_flags`: Flags user can apply to grievances

--- a/README.md
+++ b/README.md
@@ -2,12 +2,165 @@
 This repository holds the files of the openIMIS Backend grievance social protection reference module.
 It is dedicated to be deployed as a module of [openimis-be_py](https://github.com/openimis/openimis-be_py).
 
+## Features
+
+- **Grievance Management**: Create, update, and track grievances
+- **Comments System**: Add comments and resolutions to grievance
+- **Configurable Categories and Flags**: Define custom grievance types and flags
+- **Rights-Based Access Control**: Fine-grained permissions for categories and flags
+- **Hierarchical Categories**: Support for multi-level category structures
+- **Priority Management**: Automatic priority assignment based on category/flag configuration
+- **Resolution Tracking**: Configure resolution times by category
+
 ## Configuration options (can be changed via core.ModuleConfiguration)
-Rights required:
+
+### Basic Configuration
+
 * `resolution_times`: time to resolution in form of CRON timedelta: {days},{hours} where days are values between <0, 99) and hours are between 0 and 24. 
 (default: `5,0`)
+
 * `default_resolution`: The field will be in form of the JSON dictionary with pairs like: 
 Key - type of the grievance, 
 Value - time to resolution in form of CRON timedelta: `{days},{hours}` where days are values between <0, 99) and hours are between 0 and 24.
 (default: `{Default: '5,0'}`)
-Note: If for given type of the grievance time is not provided then default value is used from `resolution_times`. 
+Note: If for given type of the grievance time is not provided then default value is used from `resolution_times`.
+
+### Categories Configuration
+
+The module supports both simple and enhanced category configurations:
+
+#### Simple Format (backward compatible)
+```json
+{
+  "grievance_types": ["complaint", "feedback", "appeal"]
+}
+```
+
+#### Enhanced Format with Permissions and Resolution Times
+```json
+{
+  "grievance_flags": [
+    "public",
+    {
+      "name": "sensitive",
+      "priority": "Critical",
+      "permissions":["127001", "127002"]
+    }
+  ],
+  "grievance_types": [
+    "simple_category",
+    {
+      "name": "complaint",
+      "priority": "High",
+      "permissions": ["127001", "127002"],  // Grants all access to users with either permission
+      "default_flags": ["urgent"],
+      "resolution_times": "3,0",  // 3 days, 0 hours
+      "children": [
+        {
+          "name": "service_complaint",
+          "permissions": ["127003"],  // Child can override with its own permissions
+          "resolution_times": "2,12"  // Overrides parent's resolution time
+        },
+        {
+          "name": "general_complaint"
+          // Inherits parent's resolution_times (3,0) and permissions
+        }
+      ]
+    }
+  ]
+}
+```
+
+##### Resolution Times Priority
+Resolution times are determined in the following order:
+1. Category-specific `resolution_times` (with inheritance from parent categories)
+2. Legacy `default_resolution` configuration for the category
+3. Global `resolution_times` configuration
+4. Default value `5,0` (5 days, 0 hours)
+
+##### Example Configuration
+```json
+{
+  "resolution_times": "5,0",  // Global default: 5 days
+  "default_resolution": {     // Legacy configuration (still supported)
+    "feedback": "7,0"
+  },
+  "grievance_types": [
+    {
+      "name": "complaint",
+      "resolution_times": "3,0",  // Category-specific: 3 days
+      "children": [
+        {
+          "name": "urgent_complaint",
+          "resolution_times": "1,0"  // Override: 1 day
+        },
+        {
+          "name": "general_complaint"  // Inherits parent's 3 days
+        }
+      ]
+    },
+    "feedback"  // Uses default_resolution: 7 days
+  ]
+}
+
+### Flags Configuration
+
+Similarly, flags support both simple and enhanced formats:
+
+#### Simple Format
+```json
+{
+  "grievance_flags": ["urgent", "sensitive"]
+}
+```
+
+#### Enhanced Format with Permissions
+```json
+{
+  "grievance_flags": [
+    "public",
+    {
+      "name": "sensitive",
+      "priority": "Critical",
+      "permissions": ["127004", "127005"]  // Grants all access
+    }
+  ]
+}
+```
+
+## Permissions
+
+### Query Permissions
+- `127000`: View grievances
+- `127001`: Create grievances
+- `127002`: Update grievances
+- `127003`: Delete grievances
+- `127004`: View comments
+- `127005`: Create comments
+- `127006`: Resolve grievances
+
+### Category and Flag Permissions
+- Child categories inherit parent permissions unless explicitly overridden
+- Grievances queries are automatically filtered based on user permissions
+
+## GraphQL API
+
+### Configuration Query Fields
+The `grievance_config` query returns:
+- `grievance_types`: Flat list of accessible categories
+- `grievance_flags`: List of accessible flags
+- `grievance_channels`: Available channels
+- `grievance_categories_hierarchical`: Hierarchical category structure
+- `grievance_flags_detailed`: Detailed flag information with permissions
+- `accessible_categories`: Categories user can create grievances in
+- `accessible_flags`: Flags user can apply to grievances
+
+## Access Control Features
+
+1. **Category-Based Filtering**: Users only see grievances in categories they have permission to view
+2. **Flag-Based Filtering**: Grievances with restricted flags are hidden from unauthorized users
+3. **Hierarchical Permissions**: 
+   - Children inherit parent permissions by default
+   - Children can override with more restrictive permissions
+   - Users see only accessible parts of the hierarchy
+4. **Create/Update Validation**: System validates permissions before allowing grievance operations

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The grievance module automatically generates permission IDs using Django's auth_
 3. **Access Levels** (based on user's rights):
    - **Restricted Access** (`restricted_read` right): 
      - If `visible_fields` is configured: Users see only fields listed in `visible_fields`
-     - If `visible_fields` is not configured: Users see only basic info (id, status, dates, category, priority)
+     - If `visible_fields` is not configured: Users see only basic info (id, status, category, priority, date_created)
      - Non-visible fields show as "[Restricted]" for text fields or null for other types
      - Can only filter queries on visible fields
    - **Read Access** (`read` right): 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,15 @@ It is dedicated to be deployed as a module of [openimis-be_py](https://github.co
 - **Hierarchical Categories**: Support for multi-level category structures with permission inheritance
 - **Priority Management**: Automatic priority assignment based on category/flag configuration
 - **Resolution Tracking**: Configure resolution times by category
+- **Default Category Support**: Automatic assignment of 'uncategorized' type for tickets without explicit category
 
 ## Configuration options (can be changed via core.ModuleConfiguration)
 
 ### Basic Configuration
+
+* `default_grievance_type`: The default category assigned to tickets when no category is specified. 
+(default: `'uncategorized'`)
+Note: This type is automatically added to the grievance_types list with `['read', 'update']` permissions if not already present.
 
 * `resolution_times`: time to resolution in form of CRON timedelta: {days},{hours} where days are values between <0, 99) and hours are between 0 and 24. 
 (default: `5,0`)
@@ -40,6 +45,7 @@ The module supports both simple and enhanced category configurations:
 #### Enhanced Format with Auto-Generated Permission IDs
 ```json
 {
+  "default_grievance_type": "uncategorized",
   "grievance_flags": [
     "public",
     {

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -1,0 +1,294 @@
+import logging
+from django.apps import apps
+from django.core.exceptions import PermissionDenied
+
+logger = logging.getLogger(__name__)
+
+class GrievanceAccessControl:
+    """
+    Handles rights-based access control for grievance categories and flags.
+    
+    Access rules:
+    1. Categories/flags can have permission requirements using numeric permission codes
+    2. Children inherit parent's permissions unless overridden
+    3. Users must have ANY of the listed permissions for access
+    4. Empty permissions list means no restrictions (backward compatibility)
+    """
+    
+    @classmethod
+    def check_category_permission(cls, user, category_name):
+        """
+        Check if user has permission for category
+        
+        Args:
+            user: Django user object
+            category_name: Full category name (e.g., "complaint" or "complaint|service_complaint")
+        
+        Returns:
+            bool: True if user has permission or no permissions defined
+        """
+        if not user or user.is_anonymous:
+            return False
+        
+        from .apps import TicketConfig
+        
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        if not processed_categories or category_name not in processed_categories:
+            # If no processed categories or category not found, allow access
+            return True
+        
+        category_info = processed_categories[category_name]
+        permissions = category_info.get('permissions', {})
+        
+        # If no permissions defined, allow access (backward compatibility)
+        if not permissions:
+            return True
+        
+        # Handle list format - if user has ANY permission in the list, they have access
+        if isinstance(permissions, list):
+            for perm_code in permissions:
+                if user.has_perm(perm_code):
+                    return True
+            return False
+        
+        # Check inherited permissions from parent
+        parent_name = category_info.get('parent')
+        if parent_name:
+            return cls.check_category_permission(user, parent_name)
+        
+        return True
+    
+    @classmethod
+    def check_flag_permission(cls, user, flag_name):
+        """
+        Check if user has permission for flag
+        
+        Args:
+            user: Django user object
+            flag_name: Flag name
+        
+        Returns:
+            bool: True if user has permission or no permissions defined
+        """
+        if not user or user.is_anonymous:
+            return False
+        
+        from .apps import TicketConfig
+        
+        processed_flags = getattr(TicketConfig, 'processed_flags', {})
+        if not processed_flags or flag_name not in processed_flags:
+            # If no processed flags or flag not found, allow access
+            return True
+        
+        flag_info = processed_flags[flag_name]
+        permissions = flag_info.get('permissions', {})
+        
+        # If no permissions defined, allow access
+        if not permissions:
+            return True
+        
+        # Handle list format - if user has ANY permission in the list, they have access
+        if isinstance(permissions, list):
+            for perm_code in permissions:
+                if user.has_perm(perm_code):
+                    return True
+            return False
+        
+        return True
+    
+    @classmethod
+    def get_accessible_categories(cls, user, include_children=True):
+        """
+        Return list of categories accessible to the user.
+        
+        Args:
+            user: The user to check access for
+            include_children: If True, includes child categories in flat format
+        
+        Returns:
+            List of category names the user can access
+        """
+        from .apps import TicketConfig
+        
+        # Start with all grievance_types for backward compatibility
+        all_categories = list(TicketConfig.grievance_types)
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        
+        if not processed_categories:
+            return all_categories
+        
+        accessible_categories = []
+        
+        for category_name in all_categories:
+            if cls.check_category_permission(user, category_name):
+                if include_children or '|' not in category_name:
+                    accessible_categories.append(category_name)
+        
+        return accessible_categories
+    
+    @classmethod
+    def get_category_hierarchy(cls, user):
+        """
+        Return hierarchical structure of categories accessible to the user.
+        
+        Returns:
+            List of category dicts with hierarchical structure
+        """
+        from .apps import TicketConfig
+        
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        if not processed_categories:
+            # Return flat list as hierarchy if no processed categories
+            return [{"name": cat, "children": []} for cat in TicketConfig.grievance_types]
+        
+        hierarchy = []
+        
+        # Build hierarchy from processed categories
+        for category_name, category_info in processed_categories.items():
+            if not category_info.get('parent') and cls.check_category_permission(user, category_name):
+                category_dict = {
+                    'name': category_name,
+                    'priority': category_info.get('priority', 'Medium'),
+                    'permissions': category_info.get('permissions', []),
+                    'default_flags': category_info.get('default_flags', []),
+                    'children': []
+                }
+                
+                # Add accessible children
+                for child_name, child_info in processed_categories.items():
+                    if child_info.get('parent') == category_name and cls.check_category_permission(user, child_name):
+                        child_dict = {
+                            'name': child_name.split('|')[-1],  # Just the child part
+                            'full_name': child_name,
+                            'priority': child_info.get('priority', category_info.get('priority', 'Medium')),
+                            'permissions': child_info.get('permissions', []),
+                            'default_flags': child_info.get('default_flags', [])
+                        }
+                        category_dict['children'].append(child_dict)
+                
+                hierarchy.append(category_dict)
+        
+        return hierarchy
+    
+    @classmethod
+    def get_accessible_flags(cls, user):
+        """Return list of flags accessible to the user"""
+        from .apps import TicketConfig
+        
+        # Start with all grievance_flags
+        all_flags = list(TicketConfig.grievance_flags)
+        processed_flags = getattr(TicketConfig, 'processed_flags', {})
+        
+        if not processed_flags:
+            return all_flags
+        
+        accessible_flags = []
+        
+        for flag_name in all_flags:
+            if cls.check_flag_permission(user, flag_name):
+                accessible_flags.append(flag_name)
+        
+        return accessible_flags
+    
+    @classmethod
+    def validate_ticket_access(cls, user, category, flags=None):
+        """
+        Validate if user can create/view ticket with given category and flags.
+        Raises PermissionDenied if access is not allowed.
+        """
+        # Check category access
+        if category and not cls.check_category_permission(user, category):
+            raise PermissionDenied(f"User does not have permission to create ticket with category: {category}")
+        
+        # Check flags access
+        if flags:
+            flag_list = flags.split() if isinstance(flags, str) else flags
+            for flag in flag_list:
+                if flag and not cls.check_flag_permission(user, flag):
+                    raise PermissionDenied(f"User does not have permission to use flag: {flag}")
+    
+    @classmethod
+    def get_category_defaults(cls, category_name):
+        """Get default flags and priority for a category"""
+        from .apps import TicketConfig
+        
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        if not processed_categories or category_name not in processed_categories:
+            return {'priority': 'Medium', 'default_flags': []}
+        
+        category_info = processed_categories[category_name]
+        return {
+            'priority': category_info.get('priority', 'Medium'),
+            'default_flags': category_info.get('default_flags', [])
+        }
+    
+    @classmethod
+    def get_effective_priority(cls, category_name, flag_names=None):
+        """
+        Get the effective priority for a ticket based on category and flags.
+        Higher priority wins (Critical > High > Medium > Low).
+        """
+        from .apps import TicketConfig
+        
+        priorities = ['Low', 'Medium', 'High', 'Critical']
+        max_priority = 'Medium'  # Default
+        
+        # Check category priority
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        if processed_categories and category_name in processed_categories:
+            cat_priority = processed_categories[category_name].get('priority', 'Medium')
+            if priorities.index(cat_priority) > priorities.index(max_priority):
+                max_priority = cat_priority
+        
+        # Check flag priorities
+        if flag_names:
+            processed_flags = getattr(TicketConfig, 'processed_flags', {})
+            flag_list = flag_names.split() if isinstance(flag_names, str) else flag_names
+            
+            for flag_name in flag_list:
+                if processed_flags and flag_name in processed_flags:
+                    flag_priority = processed_flags[flag_name].get('priority', 'Medium')
+                    if priorities.index(flag_priority) > priorities.index(max_priority):
+                        max_priority = flag_priority
+        
+        return max_priority
+    
+    @classmethod
+    def filter_ticket_queryset(cls, queryset, user):
+        """
+        Filter a ticket queryset based on user's category and flag view permissions.
+        
+        Args:
+            queryset: Django queryset of tickets
+            user: User to check permissions for
+            
+        Returns:
+            Filtered queryset
+        """
+        from .apps import TicketConfig
+        
+        # Get accessible categories for viewing
+        accessible_categories = cls.get_accessible_categories(user)
+        
+        # Filter tickets by accessible categories
+        if accessible_categories is not None:
+            # Only filter if we have processed categories (for backward compatibility)
+            if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
+                queryset = queryset.filter(category__in=accessible_categories)
+        
+        # Further filter by flag permissions if needed
+        if hasattr(TicketConfig, 'processed_flags') and TicketConfig.processed_flags:
+            # Get flags that require permissions to view
+            restricted_flags = []
+            for flag_name, flag_info in TicketConfig.processed_flags.items():
+                permissions = flag_info.get('permissions', [])
+                # If flag has any permissions, check if user has at least one
+                if permissions and not cls.check_flag_permission(user, flag_name):
+                    restricted_flags.append(flag_name)
+            
+            # Exclude tickets with restricted flags
+            if restricted_flags:
+                for flag in restricted_flags:
+                    queryset = queryset.exclude(flags__icontains=flag)
+        
+        return queryset

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -379,7 +379,7 @@ class GrievanceAccessControl:
                 return visible_fields.copy()
 
         # If no visible_fields configured, restricted users see basic fields only
-        return ['id', 'status', 'date_created']
+        return ['id', 'status', 'category', 'priority', 'date_created']
 
     @classmethod
     def filter_fields_for_user(cls, user, category_name, available_fields):

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -2,7 +2,7 @@ import logging
 import re
 from django.core.exceptions import PermissionDenied
 
-from .apps import TicketConfig
+from .apps import TicketConfig, CATEGORY_SEPARATOR
 
 logger = logging.getLogger(__name__)
 
@@ -416,7 +416,7 @@ class GrievanceAccessControl:
     def _build_category_dict(cls, name, info, user, parent_info=None, is_child=False):
         """Build a category dictionary with common fields"""
         base_dict = {
-            'name': name.split('|')[-1] if is_child else name,
+            'name': name.split(CATEGORY_SEPARATOR)[-1] if is_child else name,
             'priority': info.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium'),
             'permissions': info.get('permissions', []),
             'default_flags': info.get('default_flags', []),
@@ -424,7 +424,7 @@ class GrievanceAccessControl:
         }
 
         if is_child:
-            base_dict['full_name'] = name.replace('|', ' ')
+            base_dict['full_name'] = name
         else:
             base_dict['children'] = []
 

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -15,78 +15,82 @@ class GrievanceAccessControl:
     3. Restricted view shows limited information based on restricted_read right
     """
 
-    @classmethod
-    def check_category_access(cls, user, category_name, access_type='read'):
-        """
-        Check if user has specific access to a category.
-        
-        Args:
-            user: Django user object
-            category_name: Full category name
-            access_type: Type of access ('restricted_read', 'read', 'write', 'update')
-        
-        Returns:
-            bool: True if user has the requested access
-        """
-        if not user or user.is_anonymous:
-            return False
-        
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        if not processed_categories or category_name not in processed_categories:
-            # No restrictions defined - return None to indicate no restrictions
-            return None
-        
-        category_info = processed_categories[category_name]
-        generated_rights = category_info.get('generated_rights', {})
-        
-        # If no rights generated, no restrictions
-        if not generated_rights:
-            return None
-        
-        # Check if user has the specific right
-        required_right = generated_rights.get(access_type)
-        if not required_right:
-            return False
-        
-        # Use the built-in has_perm method from User model
-        return user.has_perm(str(required_right))
-    
-    @classmethod
-    def check_flag_access(cls, user, flag_name, access_type='read'):
-        """
-        Check if user has specific access to a flag.
-        
-        Args:
-            user: Django user object
-            flag_name: Flag name
-            access_type: Type of access ('restricted_read', 'read', 'write')
-        
-        Returns:
-            bool: True if user has the requested access
-        """
-        if not user or user.is_anonymous:
-            return False
+    @classmethod  
+    def _check_access(cls, user, name, access_type, config_attr):  
+        """  
+        Generic access checker for category or flag.  
 
-        processed_flags = getattr(TicketConfig, 'processed_flags', {})
-        if not processed_flags or flag_name not in processed_flags:
-            # No restrictions defined - return None to indicate no restrictions
-            return None
-        
-        flag_info = processed_flags[flag_name]
-        generated_rights = flag_info.get('generated_rights', {})
+        Args:  
+            user: Django user object  
+            name: Category or flag name  
+            access_type: Type of access ('restricted_read', 'read', 'write', 'update')  
+            config_attr: 'processed_categories' or 'processed_flags'  
+
+        Returns:  
+            bool: True if user has the requested access, False if denied  
+        """  
+        if not user or user.is_anonymous:  
+            return False  
+
+        processed = getattr(TicketConfig, config_attr, {})  
+        if not processed or name not in processed:  
+            return True  
+
+        info = processed[name]  
+        generated_rights = info.get('generated_rights', {})
         
         # If no rights generated, no restrictions
         if not generated_rights:
-            return None
+            return True
         
         # Check if user has the specific right
         required_right = generated_rights.get(access_type)
-        if not required_right:
-            return False
-        
-        # Use the built-in has_perm method from User model
-        return user.has_perm(str(required_right))
+
+        if not required_right:  
+            return False  
+
+        return user.has_perm(str(required_right))  
+
+    @classmethod  
+    def check_category_access(cls, user, category_name, access_type='read'):  
+        return cls._check_access(user, category_name, access_type, 'processed_categories')
     
+    @classmethod  
+    def check_flag_access(cls, user, flag_name, access_type='read'):  
+        return cls._check_access(user, flag_name, access_type, 'processed_flags')
+    
+    @classmethod
+    def can_view_category(cls, user, category_name):
+        """Check if user can view a category (has either read or restricted_read access)"""
+        return (cls.check_category_access(user, category_name, 'read') is True or 
+                cls.check_category_access(user, category_name, 'restricted_read') is True)
+    
+    @classmethod
+    def can_view_flag(cls, user, flag_name):
+        """Check if user can view a flag (has either read or restricted_read access)"""
+        return (cls.check_flag_access(user, flag_name, 'read') is True or 
+                cls.check_flag_access(user, flag_name, 'restricted_read') is True)
+    
+    @classmethod
+    def has_category_restrictions(cls, category_name):
+        """Check if a category has any access restrictions"""
+        processed = getattr(TicketConfig, 'processed_categories', {})
+        if not processed or category_name not in processed:
+            return False
+        info = processed[category_name]
+        generated_rights = info.get('generated_rights', {})
+        return bool(generated_rights)  
+
+    @classmethod
+    def has_flag_restrictions(cls, flag_name):
+        """Check if a flag has any access restrictions"""
+        processed = getattr(TicketConfig, 'processed_flags', {})
+        if not processed or flag_name not in processed:
+            return False
+        info = processed[flag_name]
+        generated_rights = info.get('generated_rights', {})
+        return bool(generated_rights)  
+
     @classmethod
     def get_user_access_level(cls, user, category_name=None, flag_names=None):
         """
@@ -100,25 +104,26 @@ class GrievanceAccessControl:
         
         # Check category access
         if category_name:
-            # Check for full access (create, update, delete)
-            create_access = cls.check_category_access(user, category_name, 'create')
-            update_access = cls.check_category_access(user, category_name, 'update')
-            delete_access = cls.check_category_access(user, category_name, 'delete')
-            read_access = cls.check_category_access(user, category_name, 'read')
-            restricted_access = cls.check_category_access(user, category_name, 'restricted_read')
-            
-            # Skip if category has no restrictions
-            if read_access is None and restricted_access is None:
-                category_access = None  # No restrictions
-            elif create_access or update_access or delete_access:
-                # If user has any write permission, they have full access
-                category_access = 'full'
-            elif read_access:
-                category_access = 'read'
-            elif restricted_access:
-                category_access = 'restricted'
+            # Check if category has restrictions
+            if not cls.has_category_restrictions(category_name):
+                category_access = 'full'  # No restrictions means full access
             else:
-                category_access = 'none'
+                # Check for full access (create, update, delete)
+                create_access = cls.check_category_access(user, category_name, 'create')
+                update_access = cls.check_category_access(user, category_name, 'update')
+                delete_access = cls.check_category_access(user, category_name, 'delete')
+                read_access = cls.check_category_access(user, category_name, 'read')
+                restricted_access = cls.check_category_access(user, category_name, 'restricted_read')
+                
+                if create_access or update_access or delete_access:
+                    # If user has any write permission, they have full access
+                    category_access = 'full'
+                elif read_access:
+                    category_access = 'read'
+                elif restricted_access:
+                    category_access = 'restricted'
+                else:
+                    category_access = 'none'
         
         # Check flag access - most restrictive across different flags
         if flag_names:
@@ -126,16 +131,16 @@ class GrievanceAccessControl:
             flag_accesses = []
             
             for flag in flag_list:
+                # Skip flags with no restrictions
+                if not cls.has_flag_restrictions(flag):
+                    continue  # No restrictions means we don't need to check
+                
                 # Check each access level - highest permission for each individual flag
                 create_access = cls.check_flag_access(user, flag, 'create')
                 update_access = cls.check_flag_access(user, flag, 'update')
                 delete_access = cls.check_flag_access(user, flag, 'delete')
                 read_access = cls.check_flag_access(user, flag, 'read')
                 restricted_access = cls.check_flag_access(user, flag, 'restricted_read')
-                
-                # Skip flags with no restrictions (None means no restrictions)
-                if read_access is None and restricted_access is None:
-                    continue
                 
                 # For each flag, determine the actual access level
                 if create_access or update_access or delete_access:
@@ -190,13 +195,12 @@ class GrievanceAccessControl:
         return 'full'
     
     @classmethod
-    def get_accessible_categories(cls, user, min_access='restricted_read'):
+    def get_accessible_categories(cls, user):
         """
         Return list of categories accessible to the user.
         
         Args:
             user: The user to check access for
-            min_access: Minimum access level required ('restricted_read', 'read', 'write')
         
         Returns:
             List of category names the user can access
@@ -211,14 +215,13 @@ class GrievanceAccessControl:
         accessible_categories = []
         
         for category_name in all_categories:
-            access = cls.check_category_access(user, category_name, min_access)
-            if access is True or access is None:  # True = has access, None = no restrictions
+            if cls.can_view_category(user, category_name):
                 accessible_categories.append(category_name)
         
         return accessible_categories
     
     @classmethod
-    def get_accessible_flags(cls, user, min_access='restricted_read'):
+    def get_accessible_flags(cls, user):
         """Return list of flags accessible to the user"""
         
         all_flags = list(TicketConfig.grievance_flags)
@@ -230,8 +233,7 @@ class GrievanceAccessControl:
         accessible_flags = []
         
         for flag_name in all_flags:
-            access = cls.check_flag_access(user, flag_name, min_access)
-            if access is True or access is None:  # True = has access, None = no restrictions
+            if cls.can_view_flag(user, flag_name):
                 accessible_flags.append(flag_name)
         
         return accessible_flags
@@ -270,7 +272,7 @@ class GrievanceAccessControl:
         """
         
         # Get categories user can at least view with restricted access
-        accessible_categories = cls.get_accessible_categories(user, 'restricted_read')
+        accessible_categories = cls.get_accessible_categories(user)
         
         # Filter tickets by accessible categories
         if accessible_categories is not None:
@@ -283,12 +285,8 @@ class GrievanceAccessControl:
             restricted_flags = []
             for flag_name, flag_info in TicketConfig.processed_flags.items():
                 if flag_info.get('generated_rights'):
-                    # Check if user has either read or restricted_read access
-                    read_access = cls.check_flag_access(user, flag_name, 'read')
-                    restricted_access = cls.check_flag_access(user, flag_name, 'restricted_read')
-                    
-                    # If user has neither read nor restricted_read, they can't access tickets with this flag
-                    if not read_access and not restricted_access:
+                    # If user can't view this flag, they can't access tickets with this flag
+                    if not cls.can_view_flag(user, flag_name):
                         restricted_flags.append(flag_name)
             
             # Exclude tickets with completely restricted flags
@@ -410,6 +408,24 @@ class GrievanceAccessControl:
         return filtered_fields
     
     @classmethod
+    def _build_category_dict(cls, name, info, user, parent_info=None, is_child=False):
+        """Build a category dictionary with common fields"""
+        base_dict = {
+            'name': name.split('|')[-1] if is_child else name,
+            'priority': info.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium'),
+            'permissions': info.get('permissions', []),
+            'default_flags': info.get('default_flags', []),
+            'access_level': cls.get_user_access_level(user, name)
+        }
+        
+        if is_child:
+            base_dict['full_name'] = name
+        else:
+            base_dict['children'] = []
+            
+        return base_dict
+    
+    @classmethod
     def get_category_hierarchy(cls, user):
         """Return hierarchical structure of categories accessible to the user"""
         
@@ -422,32 +438,16 @@ class GrievanceAccessControl:
         # Build hierarchy from processed categories
         for category_name, category_info in processed_categories.items():
             if not category_info.get('parent'):
-                access = cls.check_category_access(user, category_name, 'restricted_read')
-                if access is True or access is None:  # Has access or no restrictions
-                    category_dict = {
-                    'name': category_name,
-                    'priority': category_info.get('priority', 'Medium'),
-                    'permissions': category_info.get('permissions', []),
-                    'default_flags': category_info.get('default_flags', []),
-                    'children': [],
-                    'access_level': cls.get_user_access_level(user, category_name)
-                }
-                
-                # Add accessible children
-                for child_name, child_info in processed_categories.items():
-                    if child_info.get('parent') == category_name:
-                        child_access = cls.check_category_access(user, child_name, 'restricted_read')
-                        if child_access is True or child_access is None:  # Has access or no restrictions
-                            child_dict = {
-                            'name': child_name.split('|')[-1],
-                            'full_name': child_name,
-                            'priority': child_info.get('priority', category_info.get('priority', 'Medium')),
-                            'permissions': child_info.get('permissions', []),
-                            'default_flags': child_info.get('default_flags', []),
-                            'access_level': cls.get_user_access_level(user, child_name)
-                            }
-                            category_dict['children'].append(child_dict)
-                
-                hierarchy.append(category_dict)
+                if cls.can_view_category(user, category_name):
+                    category_dict = cls._build_category_dict(category_name, category_info, user)
+                    
+                    # Add accessible children
+                    for child_name, child_info in processed_categories.items():
+                        if child_info.get('parent') == category_name:
+                            if cls.can_view_category(user, child_name):  # Has access
+                                child_dict = cls._build_category_dict(child_name, child_info, user, category_info, is_child=True)
+                                category_dict['children'].append(child_dict)
+                    
+                    hierarchy.append(category_dict)
         
         return hierarchy

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -119,14 +119,14 @@ class GrievanceAccessControl:
     @classmethod
     def can_view_category(cls, user, category_name):
         """Check if user can view a category (has either read or restricted_read access)"""
-        return (cls.check_category_access(user, category_name, cls.PERM_READ) or
-                cls.check_category_access(user, category_name, cls.PERM_RESTRICTED_READ))
+        return (cls.check_category_access(user, category_name, cls.PERM_READ)
+                or cls.check_category_access(user, category_name, cls.PERM_RESTRICTED_READ))
 
     @classmethod
     def can_view_flag(cls, user, flag_name):
         """Check if user can view a flag (has either read or restricted_read access)"""
-        return (cls.check_flag_access(user, flag_name, cls.PERM_READ) or
-                cls.check_flag_access(user, flag_name, cls.PERM_RESTRICTED_READ))
+        return (cls.check_flag_access(user, flag_name, cls.PERM_READ)
+                or cls.check_flag_access(user, flag_name, cls.PERM_RESTRICTED_READ))
 
     @classmethod
     def _has_restrictions(cls, name, config_attr):

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -23,14 +23,21 @@ class GrievanceAccessControl:
     ACCESS_READ = 'read'
     ACCESS_FULL = 'full'
 
+    # Permission type constants
+    PERM_RESTRICTED_READ = 'restricted_read'
+    PERM_READ = 'read'
+    PERM_CREATE = 'create'
+    PERM_UPDATE = 'update'
+    PERM_DELETE = 'delete'
+
     # Fallback to the module's standard ticket permissions when a category/flag
     # has generated_rights but the specific permission type is not among them.
     # Unconfigured standard types defer to the existing role-based permissions.
     _DEFAULT_PERM_FALLBACK = {
-        'read': 'gql_query_tickets_perms',
-        'create': 'gql_mutation_create_tickets_perms',
-        'update': 'gql_mutation_update_tickets_perms',
-        'delete': 'gql_mutation_delete_tickets_perms',
+        PERM_READ: 'gql_query_tickets_perms',
+        PERM_CREATE: 'gql_mutation_create_tickets_perms',
+        PERM_UPDATE: 'gql_mutation_update_tickets_perms',
+        PERM_DELETE: 'gql_mutation_delete_tickets_perms',
     }
 
     @staticmethod
@@ -79,7 +86,7 @@ class GrievanceAccessControl:
             # Grievance-specific types like restricted_read have no fallback.
             fallback_attr = cls._DEFAULT_PERM_FALLBACK.get(access_type)
             if not fallback_attr:
-                if access_type not in ('restricted_read',):
+                if access_type not in (cls.PERM_RESTRICTED_READ,):
                     logger.warning(
                         "No fallback permission for access_type='%s' "
                         "(name=%s, config_attr=%s). Denying access.",
@@ -101,24 +108,24 @@ class GrievanceAccessControl:
         return user.has_perm(str(required_right))
 
     @classmethod
-    def check_category_access(cls, user, category_name, access_type='read'):
+    def check_category_access(cls, user, category_name, access_type=PERM_READ):
         return cls._check_access(user, category_name, access_type, 'processed_categories')
 
     @classmethod
-    def check_flag_access(cls, user, flag_name, access_type='read'):
+    def check_flag_access(cls, user, flag_name, access_type=PERM_READ):
         return cls._check_access(user, flag_name, access_type, 'processed_flags')
 
     @classmethod
     def can_view_category(cls, user, category_name):
         """Check if user can view a category (has either read or restricted_read access)"""
-        return (cls.check_category_access(user, category_name, 'read') or
-                cls.check_category_access(user, category_name, 'restricted_read'))
+        return (cls.check_category_access(user, category_name, cls.PERM_READ) or
+                cls.check_category_access(user, category_name, cls.PERM_RESTRICTED_READ))
 
     @classmethod
     def can_view_flag(cls, user, flag_name):
         """Check if user can view a flag (has either read or restricted_read access)"""
-        return (cls.check_flag_access(user, flag_name, 'read') or
-                cls.check_flag_access(user, flag_name, 'restricted_read'))
+        return (cls.check_flag_access(user, flag_name, cls.PERM_READ) or
+                cls.check_flag_access(user, flag_name, cls.PERM_RESTRICTED_READ))
 
     @classmethod
     def _has_restrictions(cls, name, config_attr):
@@ -157,11 +164,11 @@ class GrievanceAccessControl:
             if not has_restrictions_func(name):
                 return None  # No restrictions
 
-            if any(check_func(user, name, t) for t in ('create', 'update', 'delete')):
+            if any(check_func(user, name, t) for t in (cls.PERM_CREATE, cls.PERM_UPDATE, cls.PERM_DELETE)):
                 return cls.ACCESS_FULL
-            if check_func(user, name, 'read'):
+            if check_func(user, name, cls.PERM_READ):
                 return cls.ACCESS_READ
-            if check_func(user, name, 'restricted_read'):
+            if check_func(user, name, cls.PERM_RESTRICTED_READ):
                 return cls.ACCESS_RESTRICTED
             return cls.ACCESS_NONE
 
@@ -231,7 +238,7 @@ class GrievanceAccessControl:
         return [name for name in all_flags if cls.can_view_flag(user, name)]
 
     @classmethod
-    def validate_ticket_access(cls, user, category, flags=None, access_type='create'):
+    def validate_ticket_access(cls, user, category, flags=None, access_type=PERM_CREATE):
         """
         Validate if user can perform action on ticket with given category and flags.
         Raises PermissionDenied if access is not allowed.
@@ -415,7 +422,7 @@ class GrievanceAccessControl:
         }
 
         if is_child:
-            base_dict['full_name'] = name
+            base_dict['full_name'] = name.replace('|', ' ')
         else:
             base_dict['children'] = []
 

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from django.core.exceptions import PermissionDenied
+from django.db.models import Q
 
 from .apps import TicketConfig, CATEGORY_SEPARATOR
 
@@ -271,9 +272,14 @@ class GrievanceAccessControl:
         # Get categories user can at least view with restricted access
         accessible_categories = cls.get_accessible_categories(user)
 
-        # Filter tickets by accessible categories
+        # Filter tickets by accessible categories.
+        # Include NULL/blank category tickets if the default grievance type is accessible,
+        # so legacy tickets without a category remain visible.
         if TicketConfig.processed_categories:
-            queryset = queryset.filter(category__in=accessible_categories)
+            category_filter = Q(category__in=accessible_categories)
+            if TicketConfig.default_grievance_type in accessible_categories:
+                category_filter |= Q(category__isnull=True) | Q(category='')
+            queryset = queryset.filter(category_filter)
 
         # Further filter by flag permissions
         if TicketConfig.processed_flags:

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -8,236 +8,198 @@ logger = logging.getLogger(__name__)
 class GrievanceAccessControl:
     """
     Handles rights-based access control for grievance categories and flags.
-    
+
     Access rules:
     1. Categories/flags can have permissions that generate automatic rights
     2. Users need specific rights to access categories/flags
     3. Restricted view shows limited information based on restricted_read right
     """
 
-    @classmethod  
-    def _check_access(cls, user, name, access_type, config_attr):  
-        """  
-        Generic access checker for category or flag.  
+    # Access level constants
+    ACCESS_NONE = 'none'
+    ACCESS_RESTRICTED = 'restricted'
+    ACCESS_READ = 'read'
+    ACCESS_FULL = 'full'
 
-        Args:  
-            user: Django user object  
-            name: Category or flag name  
-            access_type: Type of access ('restricted_read', 'read', 'write', 'update')  
-            config_attr: 'processed_categories' or 'processed_flags'  
+    @staticmethod
+    def parse_flags(flags):
+        """Parse flags from string or list format to list."""
+        if not flags:
+            return []
+        if isinstance(flags, str):
+            return flags.split()
+        return list(flags)
 
-        Returns:  
-            bool: True if user has the requested access, False if denied  
-        """  
-        if not user or user.is_anonymous:  
-            return False  
+    @classmethod
+    def _check_access(cls, user, name, access_type, config_attr):
+        """
+        Generic access checker for category or flag.
 
-        processed = getattr(TicketConfig, config_attr, {})  
-        if not processed or name not in processed:  
-            return True  
+        Args:
+            user: Django user object
+            name: Category or flag name
+            access_type: Type of access ('restricted_read', 'read', 'write', 'update')
+            config_attr: 'processed_categories' or 'processed_flags'
 
-        info = processed[name]  
+        Returns:
+            bool: True if user has the requested access, False if denied
+        """
+        if not user or user.is_anonymous:
+            return False
+
+        processed = getattr(TicketConfig, config_attr, {})
+        if not processed or name not in processed:
+            return True
+
+        info = processed[name]
         generated_rights = info.get('generated_rights', {})
-        
+
         # If no rights generated, no restrictions
         if not generated_rights:
             return True
-        
+
         # Check if user has the specific right
         required_right = generated_rights.get(access_type)
 
-        if not required_right:  
-            return False  
+        if not required_right:
+            # No restriction configured for this access type - allow access
+            return True
 
-        return user.has_perm(str(required_right))  
+        return user.has_perm(str(required_right))
 
-    @classmethod  
-    def check_category_access(cls, user, category_name, access_type='read'):  
+    @classmethod
+    def check_category_access(cls, user, category_name, access_type='read'):
         return cls._check_access(user, category_name, access_type, 'processed_categories')
-    
-    @classmethod  
-    def check_flag_access(cls, user, flag_name, access_type='read'):  
+
+    @classmethod
+    def check_flag_access(cls, user, flag_name, access_type='read'):
         return cls._check_access(user, flag_name, access_type, 'processed_flags')
-    
+
     @classmethod
     def can_view_category(cls, user, category_name):
         """Check if user can view a category (has either read or restricted_read access)"""
-        return (cls.check_category_access(user, category_name, 'read') is True or 
-                cls.check_category_access(user, category_name, 'restricted_read') is True)
-    
+        return (cls.check_category_access(user, category_name, 'read') or
+                cls.check_category_access(user, category_name, 'restricted_read'))
+
     @classmethod
     def can_view_flag(cls, user, flag_name):
         """Check if user can view a flag (has either read or restricted_read access)"""
-        return (cls.check_flag_access(user, flag_name, 'read') is True or 
-                cls.check_flag_access(user, flag_name, 'restricted_read') is True)
-    
+        return (cls.check_flag_access(user, flag_name, 'read') or
+                cls.check_flag_access(user, flag_name, 'restricted_read'))
+
+    @classmethod
+    def _has_restrictions(cls, name, config_attr):
+        """Check if an item has any access restrictions"""
+        processed = getattr(TicketConfig, config_attr, {})
+        if not processed or name not in processed:
+            return False
+        return bool(processed[name].get('generated_rights', {}))
+
     @classmethod
     def has_category_restrictions(cls, category_name):
         """Check if a category has any access restrictions"""
-        processed = getattr(TicketConfig, 'processed_categories', {})
-        if not processed or category_name not in processed:
-            return False
-        info = processed[category_name]
-        generated_rights = info.get('generated_rights', {})
-        return bool(generated_rights)  
+        return cls._has_restrictions(category_name, 'processed_categories')
 
     @classmethod
     def has_flag_restrictions(cls, flag_name):
         """Check if a flag has any access restrictions"""
-        processed = getattr(TicketConfig, 'processed_flags', {})
-        if not processed or flag_name not in processed:
-            return False
-        info = processed[flag_name]
-        generated_rights = info.get('generated_rights', {})
-        return bool(generated_rights)  
+        return cls._has_restrictions(flag_name, 'processed_flags')
 
     @classmethod
     def get_user_access_level(cls, user, category_name=None, flag_names=None):
         """
         Determine the highest level of access a user has.
-        
+
         Returns:
             str: 'full', 'read', 'restricted', or 'none'
         """
-        category_access = None
-        flag_access = None
-        
-        # Check category access
-        if category_name:
-            # Check if category has restrictions
-            if not cls.has_category_restrictions(category_name):
-                category_access = 'full'  # No restrictions means full access
+
+        def evaluate_access(check_func, name, has_restrictions_func):
+            """
+            Evaluate access level for a single category or flag.
+
+            Returns:
+                str: 'full', 'read', 'restricted', 'none', or None (no restrictions)
+            """
+            if not has_restrictions_func(name):
+                return None  # No restrictions
+
+            if any(check_func(user, name, t) for t in ('create', 'update', 'delete')):
+                return cls.ACCESS_FULL
+            elif check_func(user, name, 'read'):
+                return cls.ACCESS_READ
+            elif check_func(user, name, 'restricted_read'):
+                return cls.ACCESS_RESTRICTED
             else:
-                # Check for full access (create, update, delete)
-                create_access = cls.check_category_access(user, category_name, 'create')
-                update_access = cls.check_category_access(user, category_name, 'update')
-                delete_access = cls.check_category_access(user, category_name, 'delete')
-                read_access = cls.check_category_access(user, category_name, 'read')
-                restricted_access = cls.check_category_access(user, category_name, 'restricted_read')
-                
-                if create_access or update_access or delete_access:
-                    # If user has any write permission, they have full access
-                    category_access = 'full'
-                elif read_access:
-                    category_access = 'read'
-                elif restricted_access:
-                    category_access = 'restricted'
-                else:
-                    category_access = 'none'
-        
-        # Check flag access - most restrictive across different flags
+                return cls.ACCESS_NONE
+
+        def min_access_level(levels):
+            """Return most restrictive among present levels."""
+            levels = [l for l in levels if l is not None]
+            if not levels:
+                return None
+
+            for level in (cls.ACCESS_NONE, cls.ACCESS_RESTRICTED, cls.ACCESS_READ, cls.ACCESS_FULL):
+                if level in levels:
+                    return level
+            return None
+
+        # Evaluate category access
+        category_access = evaluate_access(
+            cls.check_category_access,
+            category_name,
+            cls.has_category_restrictions
+        ) if category_name else None
+
+        # Evaluate flag access (most restrictive across all flags)
+        flag_accesses = []
         if flag_names:
-            flag_list = flag_names.split() if isinstance(flag_names, str) else flag_names
-            flag_accesses = []
-            
+            flag_list = cls.parse_flags(flag_names)
             for flag in flag_list:
-                # Skip flags with no restrictions
-                if not cls.has_flag_restrictions(flag):
-                    continue  # No restrictions means we don't need to check
-                
-                # Check each access level - highest permission for each individual flag
-                create_access = cls.check_flag_access(user, flag, 'create')
-                update_access = cls.check_flag_access(user, flag, 'update')
-                delete_access = cls.check_flag_access(user, flag, 'delete')
-                read_access = cls.check_flag_access(user, flag, 'read')
-                restricted_access = cls.check_flag_access(user, flag, 'restricted_read')
-                
-                # For each flag, determine the actual access level
-                if create_access or update_access or delete_access:
-                    # If user has any write permission, they have full access
-                    flag_accesses.append('full')
-                elif read_access:
-                    # Having read satisfies restricted_read requirement
-                    flag_accesses.append('read')
-                elif restricted_access:
-                    flag_accesses.append('restricted')
-                else:
-                    flag_accesses.append('none')
-            
-            # Across different flags, most restrictive wins
-            if flag_accesses:
-                if 'none' in flag_accesses:
-                    flag_access = 'none'
-                elif 'restricted' in flag_accesses:
-                    # If any flag only allows restricted access, that's the max
-                    flag_access = 'restricted'
-                elif 'read' in flag_accesses:
-                    flag_access = 'read'
-                elif 'full' in flag_accesses:
-                    flag_access = 'full'
-        
-        # Combine category and flag access
-        # Category restrictions always take precedence
-        if category_access == 'none' or flag_access == 'none':
-            return 'none'
-        
-        # If category has restricted access, that's the maximum allowed
-        if category_access == 'restricted':
-            return 'restricted'
-        
-        # If we have both category and flag access
-        if category_access is not None and flag_access is not None:
-            # Return the most restrictive access
-            if category_access == 'restricted' or flag_access == 'restricted':
-                return 'restricted'
-            elif category_access == 'read' or flag_access == 'read':
-                return 'read'
-            else:
-                return 'full'
-        
-        # If only one is set, use that
-        if category_access is not None:
-            return category_access
-        if flag_access is not None:
-            return flag_access
-            
-        # No restrictions on anything
-        return 'full'
-    
+                level = evaluate_access(
+                    cls.check_flag_access,
+                    flag,
+                    cls.has_flag_restrictions
+                )
+                if level is not None:
+                    flag_accesses.append(level)
+
+        flag_access = min_access_level(flag_accesses) if flag_accesses else None
+
+        # Most restrictive applies
+        result = min_access_level([category_access, flag_access])
+        return result if result is not None else cls.ACCESS_FULL
+
     @classmethod
     def get_accessible_categories(cls, user):
         """
         Return list of categories accessible to the user.
-        
+
         Args:
             user: The user to check access for
-        
+
         Returns:
             List of category names the user can access
         """
-
         all_categories = list(TicketConfig.grievance_types)
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        
+
         if not processed_categories:
             return all_categories
-        
-        accessible_categories = []
-        
-        for category_name in all_categories:
-            if cls.can_view_category(user, category_name):
-                accessible_categories.append(category_name)
-        
-        return accessible_categories
-    
+
+        return [name for name in all_categories if cls.can_view_category(user, name)]
+
     @classmethod
     def get_accessible_flags(cls, user):
         """Return list of flags accessible to the user"""
-        
         all_flags = list(TicketConfig.grievance_flags)
         processed_flags = getattr(TicketConfig, 'processed_flags', {})
-        
+
         if not processed_flags:
             return all_flags
-        
-        accessible_flags = []
-        
-        for flag_name in all_flags:
-            if cls.can_view_flag(user, flag_name):
-                accessible_flags.append(flag_name)
-        
-        return accessible_flags
-    
+
+        return [name for name in all_flags if cls.can_view_flag(user, name)]
+
     @classmethod
     def validate_ticket_access(cls, user, category, flags=None, access_type='create'):
         """
@@ -246,167 +208,186 @@ class GrievanceAccessControl:
         """
         # Check category access
         if category:
-            access = cls.check_category_access(user, category, access_type)
-            if access is False:  # Explicitly denied
+            if not cls.check_category_access(user, category, access_type):
                 raise PermissionDenied(f"User does not have {access_type} permission for category: {category}")
-        
+
         # Check flags access
         if flags:
-            flag_list = flags.split() if isinstance(flags, str) else flags
+            flag_list = cls.parse_flags(flags)
             for flag in flag_list:
-                access = cls.check_flag_access(user, flag, access_type)
-                if flag and access is False:  # Explicitly denied
+                if flag and not cls.check_flag_access(user, flag, access_type):
                     raise PermissionDenied(f"User does not have {access_type} permission for flag: {flag}")
-    
+
     @classmethod
     def filter_ticket_queryset(cls, queryset, user):
         """
         Filter a ticket queryset based on user's access rights.
-        
+
         Args:
             queryset: Django queryset of tickets
             user: User to check permissions for
-            
+
         Returns:
             Filtered queryset
         """
-        
         # Get categories user can at least view with restricted access
         accessible_categories = cls.get_accessible_categories(user)
-        
+
         # Filter tickets by accessible categories
-        if accessible_categories is not None:
-            if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
-                queryset = queryset.filter(category__in=accessible_categories)
-        
+        if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
+            queryset = queryset.filter(category__in=accessible_categories)
+
         # Further filter by flag permissions
         if hasattr(TicketConfig, 'processed_flags') and TicketConfig.processed_flags:
             # Get flags that user cannot access at all
-            restricted_flags = []
-            for flag_name, flag_info in TicketConfig.processed_flags.items():
-                if flag_info.get('generated_rights'):
-                    # If user can't view this flag, they can't access tickets with this flag
-                    if not cls.can_view_flag(user, flag_name):
-                        restricted_flags.append(flag_name)
-            
-            # Exclude tickets with completely restricted flags
-            if restricted_flags:
-                for flag in restricted_flags:
-                    queryset = queryset.exclude(flags__icontains=flag)
-        
+            restricted_flags = [
+                flag_name
+                for flag_name, flag_info in TicketConfig.processed_flags.items()
+                if flag_info.get('generated_rights') and not cls.can_view_flag(user, flag_name)
+            ]
+
+            # Exclude tickets with completely restricted flags using exact word boundary matching
+            # to avoid false positives (e.g., "urgent" matching "not_urgent")
+            for flag in restricted_flags:
+                # Match flag as a whole word: at start, end, or surrounded by spaces
+                queryset = queryset.exclude(flags__regex=r'(^|(?<= ))' + flag + r'($|(?= ))')
+
         return queryset
-    
+
     @classmethod
     def get_category_defaults(cls, category_name):
         """Get default flags and priority for a category"""
-        
+
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         if not processed_categories or category_name not in processed_categories:
             return {'priority': 'Medium', 'default_flags': []}
-        
+
         category_info = processed_categories[category_name]
         return {
             'priority': category_info.get('priority', 'Medium'),
             'default_flags': category_info.get('default_flags', [])
         }
-    
+
+    @classmethod
+    def _get_priority_index(cls, priority, priorities):
+        """
+        Safely get the index of a priority value, returning default index if invalid.
+
+        Args:
+            priority: Priority string to look up
+            priorities: List of valid priority values in order
+
+        Returns:
+            int: Index of priority in list, or index of 'Medium' if invalid
+        """
+        try:
+            return priorities.index(priority)
+        except ValueError:
+            logger.warning(f"Invalid priority value '{priority}', using 'Medium' as default")
+            return priorities.index('Medium')
+
     @classmethod
     def get_effective_priority(cls, category_name, flag_names=None):
         """
         Get the effective priority for a ticket based on category and flags.
         Higher priority wins (Critical > High > Medium > Low).
         """
-        
+
         priorities = ['Low', 'Medium', 'High', 'Critical']
         max_priority = 'Medium'  # Default
-        
+        max_priority_index = priorities.index(max_priority)
+
         # Check category priority
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         if processed_categories and category_name in processed_categories:
             cat_priority = processed_categories[category_name].get('priority', 'Medium')
-            if priorities.index(cat_priority) > priorities.index(max_priority):
-                max_priority = cat_priority
-        
+            cat_priority_index = cls._get_priority_index(cat_priority, priorities)
+            if cat_priority_index > max_priority_index:
+                max_priority = priorities[cat_priority_index]
+                max_priority_index = cat_priority_index
+
         # Check flag priorities
         if flag_names:
             processed_flags = getattr(TicketConfig, 'processed_flags', {})
-            flag_list = flag_names.split() if isinstance(flag_names, str) else flag_names
-            
+            flag_list = cls.parse_flags(flag_names)
+
             for flag_name in flag_list:
                 if processed_flags and flag_name in processed_flags:
                     flag_priority = processed_flags[flag_name].get('priority', 'Medium')
-                    if priorities.index(flag_priority) > priorities.index(max_priority):
-                        max_priority = flag_priority
-        
+                    flag_priority_index = cls._get_priority_index(flag_priority, priorities)
+                    if flag_priority_index > max_priority_index:
+                        max_priority = priorities[flag_priority_index]
+                        max_priority_index = flag_priority_index
+
         return max_priority
-    
+
     @classmethod
     def get_visible_fields(cls, user, category_name):
         """
         Get the list of fields visible to the user for a specific category.
-        
+
         Args:
             user: Django user object
             category_name: Full category name
-            
+
         Returns:
             list: List of field names the user can see, or None if all fields are visible
         """
-        
+
         # Check user's access level
         access_level = cls.get_user_access_level(user, category_name)
-        
+
         # Full access or no restrictions - all fields visible
-        if access_level == 'full' or access_level == 'read':
+        if access_level == cls.ACCESS_FULL or access_level == cls.ACCESS_READ:
             return None  # None means all fields visible
-        
+
         # No access - no fields visible
-        if access_level == 'none':
+        if access_level == cls.ACCESS_NONE:
             return []
-        
+
         # Restricted access - check visible_fields configuration
-        if access_level == 'restricted':
+        if access_level == cls.ACCESS_RESTRICTED:
             processed_categories = getattr(TicketConfig, 'processed_categories', {})
             if processed_categories and category_name in processed_categories:
                 category_info = processed_categories[category_name]
                 visible_fields = category_info.get('visible_fields', [])
-                
+
                 # If visible_fields is defined, return it
                 if visible_fields:
                     return visible_fields.copy()
-                
+
                 # If no visible_fields at all, restricted users see basic fields only
                 return ['id', 'status', 'date_created']
-        
+
         return []
-    
+
     @classmethod
     def filter_fields_for_user(cls, user, category_name, available_fields):
         """
         Filter the available fields based on user's access level.
-        
+
         Args:
             user: Django user object
             category_name: Full category name
             available_fields: Dict of all available fields
-            
+
         Returns:
             dict: Filtered fields the user can access
         """
         visible_fields = cls.get_visible_fields(user, category_name)
-        
+
         # If None, all fields are visible
         if visible_fields is None:
             return available_fields
-        
+
         # Filter to only visible fields
         filtered_fields = {}
         for field_name, field_config in available_fields.items():
             if field_name in visible_fields:
                 filtered_fields[field_name] = field_config
-        
+
         return filtered_fields
-    
+
     @classmethod
     def _build_category_dict(cls, name, info, user, parent_info=None, is_child=False):
         """Build a category dictionary with common fields"""
@@ -417,37 +398,37 @@ class GrievanceAccessControl:
             'default_flags': info.get('default_flags', []),
             'access_level': cls.get_user_access_level(user, name)
         }
-        
+
         if is_child:
             base_dict['full_name'] = name
         else:
             base_dict['children'] = []
-            
+
         return base_dict
-    
+
     @classmethod
     def get_category_hierarchy(cls, user):
         """Return hierarchical structure of categories accessible to the user"""
-        
+
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         if not processed_categories:
             return [{"name": cat, "children": []} for cat in TicketConfig.grievance_types]
-        
+
         hierarchy = []
-        
+
         # Build hierarchy from processed categories
         for category_name, category_info in processed_categories.items():
             if not category_info.get('parent'):
                 if cls.can_view_category(user, category_name):
                     category_dict = cls._build_category_dict(category_name, category_info, user)
-                    
+
                     # Add accessible children
                     for child_name, child_info in processed_categories.items():
                         if child_info.get('parent') == category_name:
                             if cls.can_view_category(user, child_name):  # Has access
                                 child_dict = cls._build_category_dict(child_name, child_info, user, category_info, is_child=True)
                                 category_dict['children'].append(child_dict)
-                    
+
                     hierarchy.append(category_dict)
-        
+
         return hierarchy

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -423,18 +423,28 @@ class GrievanceAccessControl:
         """Build a category dictionary with common fields"""
         base_dict = {
             'name': name.split(CATEGORY_SEPARATOR)[-1] if is_child else name,
+            'full_name': name,
             'priority': info.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium'),
             'permissions': info.get('permissions', []),
             'default_flags': info.get('default_flags', []),
-            'access_level': cls.get_user_access_level(user, name)
+            'access_level': cls.get_user_access_level(user, name),
+            'children': [],
         }
 
-        if is_child:
-            base_dict['full_name'] = name
-        else:
-            base_dict['children'] = []
-
         return base_dict
+
+    @classmethod
+    def _build_subtree(cls, parent_name, parent_info, user):
+        """Recursively build accessible children for a category"""
+        children = []
+        for child_name, child_info in TicketConfig.processed_categories.items():
+            if child_info.get('parent') == parent_name:
+                if cls.can_view_category(user, child_name):
+                    child_dict = cls._build_category_dict(
+                        child_name, child_info, user, parent_info, is_child=True)
+                    child_dict['children'] = cls._build_subtree(child_name, child_info, user)
+                    children.append(child_dict)
+        return children
 
     @classmethod
     def get_category_hierarchy(cls, user):
@@ -450,15 +460,8 @@ class GrievanceAccessControl:
             if not category_info.get('parent'):
                 if cls.can_view_category(user, category_name):
                     category_dict = cls._build_category_dict(category_name, category_info, user)
-
-                    # Add accessible children
-                    for child_name, child_info in TicketConfig.processed_categories.items():
-                        if child_info.get('parent') == category_name:
-                            if cls.can_view_category(user, child_name):  # Has access
-                                child_dict = cls._build_category_dict(
-                                    child_name, child_info, user, category_info, is_child=True)
-                                category_dict['children'].append(child_dict)
-
+                    category_dict['children'] = cls._build_subtree(
+                        category_name, category_info, user)
                     hierarchy.append(category_dict)
 
         return hierarchy

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -6,6 +6,7 @@ from .apps import TicketConfig
 
 logger = logging.getLogger(__name__)
 
+
 class GrievanceAccessControl:
     """
     Handles rights-based access control for grievance categories and flags.
@@ -174,7 +175,7 @@ class GrievanceAccessControl:
 
         def min_access_level(levels):
             """Return most restrictive among present levels."""
-            levels = [l for l in levels if l is not None]
+            levels = [lvl for lvl in levels if lvl is not None]
             if not levels:
                 return None
 
@@ -447,7 +448,8 @@ class GrievanceAccessControl:
                     for child_name, child_info in TicketConfig.processed_categories.items():
                         if child_info.get('parent') == category_name:
                             if cls.can_view_category(user, child_name):  # Has access
-                                child_dict = cls._build_category_dict(child_name, child_info, user, category_info, is_child=True)
+                                child_dict = cls._build_category_dict(
+                                    child_name, child_info, user, category_info, is_child=True)
                                 category_dict['children'].append(child_dict)
 
                     hierarchy.append(category_dict)

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from django.core.exceptions import PermissionDenied
 
 from .apps import TicketConfig
@@ -126,12 +127,11 @@ class GrievanceAccessControl:
 
             if any(check_func(user, name, t) for t in ('create', 'update', 'delete')):
                 return cls.ACCESS_FULL
-            elif check_func(user, name, 'read'):
+            if check_func(user, name, 'read'):
                 return cls.ACCESS_READ
-            elif check_func(user, name, 'restricted_read'):
+            if check_func(user, name, 'restricted_read'):
                 return cls.ACCESS_RESTRICTED
-            else:
-                return cls.ACCESS_NONE
+            return cls.ACCESS_NONE
 
         def min_access_level(levels):
             """Return most restrictive among present levels."""
@@ -182,9 +182,8 @@ class GrievanceAccessControl:
             List of category names the user can access
         """
         all_categories = list(TicketConfig.grievance_types)
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
 
-        if not processed_categories:
+        if not TicketConfig.processed_categories:
             return all_categories
 
         return [name for name in all_categories if cls.can_view_category(user, name)]
@@ -193,9 +192,8 @@ class GrievanceAccessControl:
     def get_accessible_flags(cls, user):
         """Return list of flags accessible to the user"""
         all_flags = list(TicketConfig.grievance_flags)
-        processed_flags = getattr(TicketConfig, 'processed_flags', {})
 
-        if not processed_flags:
+        if not TicketConfig.processed_flags:
             return all_flags
 
         return [name for name in all_flags if cls.can_view_flag(user, name)]
@@ -234,11 +232,11 @@ class GrievanceAccessControl:
         accessible_categories = cls.get_accessible_categories(user)
 
         # Filter tickets by accessible categories
-        if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
+        if TicketConfig.processed_categories:
             queryset = queryset.filter(category__in=accessible_categories)
 
         # Further filter by flag permissions
-        if hasattr(TicketConfig, 'processed_flags') and TicketConfig.processed_flags:
+        if TicketConfig.processed_flags:
             # Get flags that user cannot access at all
             restricted_flags = [
                 flag_name
@@ -250,7 +248,7 @@ class GrievanceAccessControl:
             # to avoid false positives (e.g., "urgent" matching "not_urgent")
             for flag in restricted_flags:
                 # Match flag as a whole word: at start, end, or surrounded by spaces
-                queryset = queryset.exclude(flags__regex=r'(^|(?<= ))' + flag + r'($|(?= ))')
+                queryset = queryset.exclude(flags__regex=r'(^|(?<= ))' + re.escape(flag) + r'($|(?= ))')
 
         return queryset
 
@@ -258,11 +256,10 @@ class GrievanceAccessControl:
     def get_category_defaults(cls, category_name):
         """Get default flags and priority for a category"""
 
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        if not processed_categories or category_name not in processed_categories:
+        if not TicketConfig.processed_categories or category_name not in TicketConfig.processed_categories:
             return {'priority': 'Medium', 'default_flags': []}
 
-        category_info = processed_categories[category_name]
+        category_info = TicketConfig.processed_categories[category_name]
         return {
             'priority': category_info.get('priority', 'Medium'),
             'default_flags': category_info.get('default_flags', [])
@@ -294,32 +291,27 @@ class GrievanceAccessControl:
         """
 
         priorities = ['Low', 'Medium', 'High', 'Critical']
-        max_priority = 'Medium'  # Default
-        max_priority_index = priorities.index(max_priority)
+        max_idx = priorities.index('Medium')
 
         # Check category priority
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        if processed_categories and category_name in processed_categories:
-            cat_priority = processed_categories[category_name].get('priority', 'Medium')
-            cat_priority_index = cls._get_priority_index(cat_priority, priorities)
-            if cat_priority_index > max_priority_index:
-                max_priority = priorities[cat_priority_index]
-                max_priority_index = cat_priority_index
+        if TicketConfig.processed_categories and category_name in TicketConfig.processed_categories:
+            cat_priority = TicketConfig.processed_categories[category_name].get('priority', 'Medium')
+            cat_idx = cls._get_priority_index(cat_priority, priorities)
+            if cat_idx > max_idx:
+                max_idx = cat_idx
 
         # Check flag priorities
         if flag_names:
-            processed_flags = getattr(TicketConfig, 'processed_flags', {})
             flag_list = cls.parse_flags(flag_names)
 
             for flag_name in flag_list:
-                if processed_flags and flag_name in processed_flags:
-                    flag_priority = processed_flags[flag_name].get('priority', 'Medium')
-                    flag_priority_index = cls._get_priority_index(flag_priority, priorities)
-                    if flag_priority_index > max_priority_index:
-                        max_priority = priorities[flag_priority_index]
-                        max_priority_index = flag_priority_index
+                if TicketConfig.processed_flags and flag_name in TicketConfig.processed_flags:
+                    flag_priority = TicketConfig.processed_flags[flag_name].get('priority', 'Medium')
+                    flag_idx = cls._get_priority_index(flag_priority, priorities)
+                    if flag_idx > max_idx:
+                        max_idx = flag_idx
 
-        return max_priority
+        return priorities[max_idx]
 
     @classmethod
     def get_visible_fields(cls, user, category_name):
@@ -338,7 +330,7 @@ class GrievanceAccessControl:
         access_level = cls.get_user_access_level(user, category_name)
 
         # Full access or no restrictions - all fields visible
-        if access_level == cls.ACCESS_FULL or access_level == cls.ACCESS_READ:
+        if access_level in (cls.ACCESS_FULL, cls.ACCESS_READ):
             return None  # None means all fields visible
 
         # No access - no fields visible
@@ -346,20 +338,16 @@ class GrievanceAccessControl:
             return []
 
         # Restricted access - check visible_fields configuration
-        if access_level == cls.ACCESS_RESTRICTED:
-            processed_categories = getattr(TicketConfig, 'processed_categories', {})
-            if processed_categories and category_name in processed_categories:
-                category_info = processed_categories[category_name]
-                visible_fields = category_info.get('visible_fields', [])
+        if TicketConfig.processed_categories and category_name in TicketConfig.processed_categories:
+            category_info = TicketConfig.processed_categories[category_name]
+            visible_fields = category_info.get('visible_fields', [])
 
-                # If visible_fields is defined, return it
-                if visible_fields:
-                    return visible_fields.copy()
+            # If visible_fields is defined, return it
+            if visible_fields:
+                return visible_fields.copy()
 
-                # If no visible_fields at all, restricted users see basic fields only
-                return ['id', 'status', 'date_created']
-
-        return []
+        # If no visible_fields configured, restricted users see basic fields only
+        return ['id', 'status', 'date_created']
 
     @classmethod
     def filter_fields_for_user(cls, user, category_name, available_fields):
@@ -381,12 +369,7 @@ class GrievanceAccessControl:
             return available_fields
 
         # Filter to only visible fields
-        filtered_fields = {}
-        for field_name, field_config in available_fields.items():
-            if field_name in visible_fields:
-                filtered_fields[field_name] = field_config
-
-        return filtered_fields
+        return {k: v for k, v in available_fields.items() if k in visible_fields}
 
     @classmethod
     def _build_category_dict(cls, name, info, user, parent_info=None, is_child=False):
@@ -410,20 +393,19 @@ class GrievanceAccessControl:
     def get_category_hierarchy(cls, user):
         """Return hierarchical structure of categories accessible to the user"""
 
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        if not processed_categories:
+        if not TicketConfig.processed_categories:
             return [{"name": cat, "children": []} for cat in TicketConfig.grievance_types]
 
         hierarchy = []
 
         # Build hierarchy from processed categories
-        for category_name, category_info in processed_categories.items():
+        for category_name, category_info in TicketConfig.processed_categories.items():
             if not category_info.get('parent'):
                 if cls.can_view_category(user, category_name):
                     category_dict = cls._build_category_dict(category_name, category_info, user)
 
                     # Add accessible children
-                    for child_name, child_info in processed_categories.items():
+                    for child_name, child_info in TicketConfig.processed_categories.items():
                         if child_info.get('parent') == category_name:
                             if cls.can_view_category(user, child_name):  # Has access
                                 child_dict = cls._build_category_dict(child_name, child_info, user, category_info, is_child=True)

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -284,11 +284,12 @@ class GrievanceAccessControl:
                 if flag_info.get('generated_rights') and not cls.can_view_flag(user, flag_name)
             ]
 
-            # Exclude tickets with completely restricted flags using exact word boundary matching
-            # to avoid false positives (e.g., "urgent" matching "not_urgent")
+            # Exclude tickets with completely restricted flags using whole-word matching.
+            # Uses POSIX-compatible patterns (no lookbehind) for PostgreSQL compatibility.
             for flag in restricted_flags:
-                # Match flag as a whole word: at start, end, or surrounded by spaces
-                queryset = queryset.exclude(flags__regex=r'(^|(?<= ))' + re.escape(flag) + r'($|(?= ))')
+                queryset = queryset.exclude(
+                    flags__regex=r'(^| )' + re.escape(flag) + r'( |$)'
+                )
 
         return queryset
 

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -14,6 +14,7 @@ class GrievanceAccessControl:
     1. Categories/flags can have permissions that generate automatic rights
     2. Users need specific rights to access categories/flags
     3. Restricted view shows limited information based on restricted_read right
+    4. Unconfigured standard permission types fall back to the module's existing role-based permissions
     """
 
     # Access level constants
@@ -21,6 +22,16 @@ class GrievanceAccessControl:
     ACCESS_RESTRICTED = 'restricted'
     ACCESS_READ = 'read'
     ACCESS_FULL = 'full'
+
+    # Fallback to the module's standard ticket permissions when a category/flag
+    # has generated_rights but the specific permission type is not among them.
+    # Unconfigured standard types defer to the existing role-based permissions.
+    _DEFAULT_PERM_FALLBACK = {
+        'read': 'gql_query_tickets_perms',
+        'create': 'gql_mutation_create_tickets_perms',
+        'update': 'gql_mutation_update_tickets_perms',
+        'delete': 'gql_mutation_delete_tickets_perms',
+    }
 
     @staticmethod
     def parse_flags(flags):
@@ -39,7 +50,7 @@ class GrievanceAccessControl:
         Args:
             user: Django user object
             name: Category or flag name
-            access_type: Type of access ('restricted_read', 'read', 'write', 'update')
+            access_type: Type of access ('restricted_read', 'read', 'create', 'update', 'delete')
             config_attr: 'processed_categories' or 'processed_flags'
 
         Returns:
@@ -63,8 +74,29 @@ class GrievanceAccessControl:
         required_right = generated_rights.get(access_type)
 
         if not required_right:
-            # No restriction configured for this access type - allow access
-            return True
+            # Permission type not configured — fall back to default core
+            # ticket permissions for standard types (read/create/update/delete).
+            # Grievance-specific types like restricted_read have no fallback.
+            fallback_attr = cls._DEFAULT_PERM_FALLBACK.get(access_type)
+            if not fallback_attr:
+                if access_type not in ('restricted_read',):
+                    logger.warning(
+                        "No fallback permission for access_type='%s' "
+                        "(name=%s, config_attr=%s). Denying access.",
+                        access_type, name, config_attr
+                    )
+                return False
+            default_perms = getattr(TicketConfig, fallback_attr, None)
+            if default_perms is None:
+                logger.error(
+                    "TicketConfig missing attribute '%s' for fallback "
+                    "permission check (access_type=%s, name=%s). Denying access.",
+                    fallback_attr, access_type, name
+                )
+                return False
+            if not default_perms:
+                return False
+            return user.has_perms(default_perms)
 
         return user.has_perm(str(required_right))
 

--- a/grievance_social_protection/access_control.py
+++ b/grievance_social_protection/access_control.py
@@ -1,6 +1,7 @@
 import logging
-from django.apps import apps
 from django.core.exceptions import PermissionDenied
+
+from .apps import TicketConfig
 
 logger = logging.getLogger(__name__)
 
@@ -9,108 +10,198 @@ class GrievanceAccessControl:
     Handles rights-based access control for grievance categories and flags.
     
     Access rules:
-    1. Categories/flags can have permission requirements using numeric permission codes
-    2. Children inherit parent's permissions unless overridden
-    3. Users must have ANY of the listed permissions for access
-    4. Empty permissions list means no restrictions (backward compatibility)
+    1. Categories/flags can have permissions that generate automatic rights
+    2. Users need specific rights to access categories/flags
+    3. Restricted view shows limited information based on restricted_read right
     """
-    
+
     @classmethod
-    def check_category_permission(cls, user, category_name):
+    def check_category_access(cls, user, category_name, access_type='read'):
         """
-        Check if user has permission for category
+        Check if user has specific access to a category.
         
         Args:
             user: Django user object
-            category_name: Full category name (e.g., "complaint" or "complaint|service_complaint")
+            category_name: Full category name
+            access_type: Type of access ('restricted_read', 'read', 'write', 'update')
         
         Returns:
-            bool: True if user has permission or no permissions defined
+            bool: True if user has the requested access
         """
         if not user or user.is_anonymous:
             return False
         
-        from .apps import TicketConfig
-        
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         if not processed_categories or category_name not in processed_categories:
-            # If no processed categories or category not found, allow access
-            return True
+            # No restrictions defined - return None to indicate no restrictions
+            return None
         
         category_info = processed_categories[category_name]
-        permissions = category_info.get('permissions', {})
+        generated_rights = category_info.get('generated_rights', {})
         
-        # If no permissions defined, allow access (backward compatibility)
-        if not permissions:
-            return True
+        # If no rights generated, no restrictions
+        if not generated_rights:
+            return None
         
-        # Handle list format - if user has ANY permission in the list, they have access
-        if isinstance(permissions, list):
-            for perm_code in permissions:
-                if user.has_perm(perm_code):
-                    return True
+        # Check if user has the specific right
+        required_right = generated_rights.get(access_type)
+        if not required_right:
             return False
         
-        # Check inherited permissions from parent
-        parent_name = category_info.get('parent')
-        if parent_name:
-            return cls.check_category_permission(user, parent_name)
-        
-        return True
+        # Use the built-in has_perm method from User model
+        return user.has_perm(str(required_right))
     
     @classmethod
-    def check_flag_permission(cls, user, flag_name):
+    def check_flag_access(cls, user, flag_name, access_type='read'):
         """
-        Check if user has permission for flag
+        Check if user has specific access to a flag.
         
         Args:
             user: Django user object
             flag_name: Flag name
+            access_type: Type of access ('restricted_read', 'read', 'write')
         
         Returns:
-            bool: True if user has permission or no permissions defined
+            bool: True if user has the requested access
         """
         if not user or user.is_anonymous:
             return False
-        
-        from .apps import TicketConfig
-        
+
         processed_flags = getattr(TicketConfig, 'processed_flags', {})
         if not processed_flags or flag_name not in processed_flags:
-            # If no processed flags or flag not found, allow access
-            return True
+            # No restrictions defined - return None to indicate no restrictions
+            return None
         
         flag_info = processed_flags[flag_name]
-        permissions = flag_info.get('permissions', {})
+        generated_rights = flag_info.get('generated_rights', {})
         
-        # If no permissions defined, allow access
-        if not permissions:
-            return True
+        # If no rights generated, no restrictions
+        if not generated_rights:
+            return None
         
-        # Handle list format - if user has ANY permission in the list, they have access
-        if isinstance(permissions, list):
-            for perm_code in permissions:
-                if user.has_perm(perm_code):
-                    return True
+        # Check if user has the specific right
+        required_right = generated_rights.get(access_type)
+        if not required_right:
             return False
         
-        return True
+        # Use the built-in has_perm method from User model
+        return user.has_perm(str(required_right))
     
     @classmethod
-    def get_accessible_categories(cls, user, include_children=True):
+    def get_user_access_level(cls, user, category_name=None, flag_names=None):
+        """
+        Determine the highest level of access a user has.
+        
+        Returns:
+            str: 'full', 'read', 'restricted', or 'none'
+        """
+        category_access = None
+        flag_access = None
+        
+        # Check category access
+        if category_name:
+            # Check for full access (create, update, delete)
+            create_access = cls.check_category_access(user, category_name, 'create')
+            update_access = cls.check_category_access(user, category_name, 'update')
+            delete_access = cls.check_category_access(user, category_name, 'delete')
+            read_access = cls.check_category_access(user, category_name, 'read')
+            restricted_access = cls.check_category_access(user, category_name, 'restricted_read')
+            
+            # Skip if category has no restrictions
+            if read_access is None and restricted_access is None:
+                category_access = None  # No restrictions
+            elif create_access or update_access or delete_access:
+                # If user has any write permission, they have full access
+                category_access = 'full'
+            elif read_access:
+                category_access = 'read'
+            elif restricted_access:
+                category_access = 'restricted'
+            else:
+                category_access = 'none'
+        
+        # Check flag access - most restrictive across different flags
+        if flag_names:
+            flag_list = flag_names.split() if isinstance(flag_names, str) else flag_names
+            flag_accesses = []
+            
+            for flag in flag_list:
+                # Check each access level - highest permission for each individual flag
+                create_access = cls.check_flag_access(user, flag, 'create')
+                update_access = cls.check_flag_access(user, flag, 'update')
+                delete_access = cls.check_flag_access(user, flag, 'delete')
+                read_access = cls.check_flag_access(user, flag, 'read')
+                restricted_access = cls.check_flag_access(user, flag, 'restricted_read')
+                
+                # Skip flags with no restrictions (None means no restrictions)
+                if read_access is None and restricted_access is None:
+                    continue
+                
+                # For each flag, determine the actual access level
+                if create_access or update_access or delete_access:
+                    # If user has any write permission, they have full access
+                    flag_accesses.append('full')
+                elif read_access:
+                    # Having read satisfies restricted_read requirement
+                    flag_accesses.append('read')
+                elif restricted_access:
+                    flag_accesses.append('restricted')
+                else:
+                    flag_accesses.append('none')
+            
+            # Across different flags, most restrictive wins
+            if flag_accesses:
+                if 'none' in flag_accesses:
+                    flag_access = 'none'
+                elif 'restricted' in flag_accesses:
+                    # If any flag only allows restricted access, that's the max
+                    flag_access = 'restricted'
+                elif 'read' in flag_accesses:
+                    flag_access = 'read'
+                elif 'full' in flag_accesses:
+                    flag_access = 'full'
+        
+        # Combine category and flag access
+        # Category restrictions always take precedence
+        if category_access == 'none' or flag_access == 'none':
+            return 'none'
+        
+        # If category has restricted access, that's the maximum allowed
+        if category_access == 'restricted':
+            return 'restricted'
+        
+        # If we have both category and flag access
+        if category_access is not None and flag_access is not None:
+            # Return the most restrictive access
+            if category_access == 'restricted' or flag_access == 'restricted':
+                return 'restricted'
+            elif category_access == 'read' or flag_access == 'read':
+                return 'read'
+            else:
+                return 'full'
+        
+        # If only one is set, use that
+        if category_access is not None:
+            return category_access
+        if flag_access is not None:
+            return flag_access
+            
+        # No restrictions on anything
+        return 'full'
+    
+    @classmethod
+    def get_accessible_categories(cls, user, min_access='restricted_read'):
         """
         Return list of categories accessible to the user.
         
         Args:
             user: The user to check access for
-            include_children: If True, includes child categories in flat format
+            min_access: Minimum access level required ('restricted_read', 'read', 'write')
         
         Returns:
             List of category names the user can access
         """
-        from .apps import TicketConfig
-        
-        # Start with all grievance_types for backward compatibility
+
         all_categories = list(TicketConfig.grievance_types)
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         
@@ -120,62 +211,16 @@ class GrievanceAccessControl:
         accessible_categories = []
         
         for category_name in all_categories:
-            if cls.check_category_permission(user, category_name):
-                if include_children or '|' not in category_name:
-                    accessible_categories.append(category_name)
+            access = cls.check_category_access(user, category_name, min_access)
+            if access is True or access is None:  # True = has access, None = no restrictions
+                accessible_categories.append(category_name)
         
         return accessible_categories
     
     @classmethod
-    def get_category_hierarchy(cls, user):
-        """
-        Return hierarchical structure of categories accessible to the user.
-        
-        Returns:
-            List of category dicts with hierarchical structure
-        """
-        from .apps import TicketConfig
-        
-        processed_categories = getattr(TicketConfig, 'processed_categories', {})
-        if not processed_categories:
-            # Return flat list as hierarchy if no processed categories
-            return [{"name": cat, "children": []} for cat in TicketConfig.grievance_types]
-        
-        hierarchy = []
-        
-        # Build hierarchy from processed categories
-        for category_name, category_info in processed_categories.items():
-            if not category_info.get('parent') and cls.check_category_permission(user, category_name):
-                category_dict = {
-                    'name': category_name,
-                    'priority': category_info.get('priority', 'Medium'),
-                    'permissions': category_info.get('permissions', []),
-                    'default_flags': category_info.get('default_flags', []),
-                    'children': []
-                }
-                
-                # Add accessible children
-                for child_name, child_info in processed_categories.items():
-                    if child_info.get('parent') == category_name and cls.check_category_permission(user, child_name):
-                        child_dict = {
-                            'name': child_name.split('|')[-1],  # Just the child part
-                            'full_name': child_name,
-                            'priority': child_info.get('priority', category_info.get('priority', 'Medium')),
-                            'permissions': child_info.get('permissions', []),
-                            'default_flags': child_info.get('default_flags', [])
-                        }
-                        category_dict['children'].append(child_dict)
-                
-                hierarchy.append(category_dict)
-        
-        return hierarchy
-    
-    @classmethod
-    def get_accessible_flags(cls, user):
+    def get_accessible_flags(cls, user, min_access='restricted_read'):
         """Return list of flags accessible to the user"""
-        from .apps import TicketConfig
         
-        # Start with all grievance_flags
         all_flags = list(TicketConfig.grievance_flags)
         processed_flags = getattr(TicketConfig, 'processed_flags', {})
         
@@ -185,32 +230,77 @@ class GrievanceAccessControl:
         accessible_flags = []
         
         for flag_name in all_flags:
-            if cls.check_flag_permission(user, flag_name):
+            access = cls.check_flag_access(user, flag_name, min_access)
+            if access is True or access is None:  # True = has access, None = no restrictions
                 accessible_flags.append(flag_name)
         
         return accessible_flags
     
     @classmethod
-    def validate_ticket_access(cls, user, category, flags=None):
+    def validate_ticket_access(cls, user, category, flags=None, access_type='create'):
         """
-        Validate if user can create/view ticket with given category and flags.
+        Validate if user can perform action on ticket with given category and flags.
         Raises PermissionDenied if access is not allowed.
         """
         # Check category access
-        if category and not cls.check_category_permission(user, category):
-            raise PermissionDenied(f"User does not have permission to create ticket with category: {category}")
+        if category:
+            access = cls.check_category_access(user, category, access_type)
+            if access is False:  # Explicitly denied
+                raise PermissionDenied(f"User does not have {access_type} permission for category: {category}")
         
         # Check flags access
         if flags:
             flag_list = flags.split() if isinstance(flags, str) else flags
             for flag in flag_list:
-                if flag and not cls.check_flag_permission(user, flag):
-                    raise PermissionDenied(f"User does not have permission to use flag: {flag}")
+                access = cls.check_flag_access(user, flag, access_type)
+                if flag and access is False:  # Explicitly denied
+                    raise PermissionDenied(f"User does not have {access_type} permission for flag: {flag}")
+    
+    @classmethod
+    def filter_ticket_queryset(cls, queryset, user):
+        """
+        Filter a ticket queryset based on user's access rights.
+        
+        Args:
+            queryset: Django queryset of tickets
+            user: User to check permissions for
+            
+        Returns:
+            Filtered queryset
+        """
+        
+        # Get categories user can at least view with restricted access
+        accessible_categories = cls.get_accessible_categories(user, 'restricted_read')
+        
+        # Filter tickets by accessible categories
+        if accessible_categories is not None:
+            if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
+                queryset = queryset.filter(category__in=accessible_categories)
+        
+        # Further filter by flag permissions
+        if hasattr(TicketConfig, 'processed_flags') and TicketConfig.processed_flags:
+            # Get flags that user cannot access at all
+            restricted_flags = []
+            for flag_name, flag_info in TicketConfig.processed_flags.items():
+                if flag_info.get('generated_rights'):
+                    # Check if user has either read or restricted_read access
+                    read_access = cls.check_flag_access(user, flag_name, 'read')
+                    restricted_access = cls.check_flag_access(user, flag_name, 'restricted_read')
+                    
+                    # If user has neither read nor restricted_read, they can't access tickets with this flag
+                    if not read_access and not restricted_access:
+                        restricted_flags.append(flag_name)
+            
+            # Exclude tickets with completely restricted flags
+            if restricted_flags:
+                for flag in restricted_flags:
+                    queryset = queryset.exclude(flags__icontains=flag)
+        
+        return queryset
     
     @classmethod
     def get_category_defaults(cls, category_name):
         """Get default flags and priority for a category"""
-        from .apps import TicketConfig
         
         processed_categories = getattr(TicketConfig, 'processed_categories', {})
         if not processed_categories or category_name not in processed_categories:
@@ -228,7 +318,6 @@ class GrievanceAccessControl:
         Get the effective priority for a ticket based on category and flags.
         Higher priority wins (Critical > High > Medium > Low).
         """
-        from .apps import TicketConfig
         
         priorities = ['Low', 'Medium', 'High', 'Critical']
         max_priority = 'Medium'  # Default
@@ -254,41 +343,111 @@ class GrievanceAccessControl:
         return max_priority
     
     @classmethod
-    def filter_ticket_queryset(cls, queryset, user):
+    def get_visible_fields(cls, user, category_name):
         """
-        Filter a ticket queryset based on user's category and flag view permissions.
+        Get the list of fields visible to the user for a specific category.
         
         Args:
-            queryset: Django queryset of tickets
-            user: User to check permissions for
+            user: Django user object
+            category_name: Full category name
             
         Returns:
-            Filtered queryset
+            list: List of field names the user can see, or None if all fields are visible
         """
-        from .apps import TicketConfig
         
-        # Get accessible categories for viewing
-        accessible_categories = cls.get_accessible_categories(user)
+        # Check user's access level
+        access_level = cls.get_user_access_level(user, category_name)
         
-        # Filter tickets by accessible categories
-        if accessible_categories is not None:
-            # Only filter if we have processed categories (for backward compatibility)
-            if hasattr(TicketConfig, 'processed_categories') and TicketConfig.processed_categories:
-                queryset = queryset.filter(category__in=accessible_categories)
+        # Full access or no restrictions - all fields visible
+        if access_level == 'full' or access_level == 'read':
+            return None  # None means all fields visible
         
-        # Further filter by flag permissions if needed
-        if hasattr(TicketConfig, 'processed_flags') and TicketConfig.processed_flags:
-            # Get flags that require permissions to view
-            restricted_flags = []
-            for flag_name, flag_info in TicketConfig.processed_flags.items():
-                permissions = flag_info.get('permissions', [])
-                # If flag has any permissions, check if user has at least one
-                if permissions and not cls.check_flag_permission(user, flag_name):
-                    restricted_flags.append(flag_name)
+        # No access - no fields visible
+        if access_level == 'none':
+            return []
+        
+        # Restricted access - check visible_fields configuration
+        if access_level == 'restricted':
+            processed_categories = getattr(TicketConfig, 'processed_categories', {})
+            if processed_categories and category_name in processed_categories:
+                category_info = processed_categories[category_name]
+                visible_fields = category_info.get('visible_fields', [])
+                
+                # If visible_fields is defined, return it
+                if visible_fields:
+                    return visible_fields.copy()
+                
+                # If no visible_fields at all, restricted users see basic fields only
+                return ['id', 'status', 'date_created']
+        
+        return []
+    
+    @classmethod
+    def filter_fields_for_user(cls, user, category_name, available_fields):
+        """
+        Filter the available fields based on user's access level.
+        
+        Args:
+            user: Django user object
+            category_name: Full category name
+            available_fields: Dict of all available fields
             
-            # Exclude tickets with restricted flags
-            if restricted_flags:
-                for flag in restricted_flags:
-                    queryset = queryset.exclude(flags__icontains=flag)
+        Returns:
+            dict: Filtered fields the user can access
+        """
+        visible_fields = cls.get_visible_fields(user, category_name)
         
-        return queryset
+        # If None, all fields are visible
+        if visible_fields is None:
+            return available_fields
+        
+        # Filter to only visible fields
+        filtered_fields = {}
+        for field_name, field_config in available_fields.items():
+            if field_name in visible_fields:
+                filtered_fields[field_name] = field_config
+        
+        return filtered_fields
+    
+    @classmethod
+    def get_category_hierarchy(cls, user):
+        """Return hierarchical structure of categories accessible to the user"""
+        
+        processed_categories = getattr(TicketConfig, 'processed_categories', {})
+        if not processed_categories:
+            return [{"name": cat, "children": []} for cat in TicketConfig.grievance_types]
+        
+        hierarchy = []
+        
+        # Build hierarchy from processed categories
+        for category_name, category_info in processed_categories.items():
+            if not category_info.get('parent'):
+                access = cls.check_category_access(user, category_name, 'restricted_read')
+                if access is True or access is None:  # Has access or no restrictions
+                    category_dict = {
+                    'name': category_name,
+                    'priority': category_info.get('priority', 'Medium'),
+                    'permissions': category_info.get('permissions', []),
+                    'default_flags': category_info.get('default_flags', []),
+                    'children': [],
+                    'access_level': cls.get_user_access_level(user, category_name)
+                }
+                
+                # Add accessible children
+                for child_name, child_info in processed_categories.items():
+                    if child_info.get('parent') == category_name:
+                        child_access = cls.check_category_access(user, child_name, 'restricted_read')
+                        if child_access is True or child_access is None:  # Has access or no restrictions
+                            child_dict = {
+                            'name': child_name.split('|')[-1],
+                            'full_name': child_name,
+                            'priority': child_info.get('priority', category_info.get('priority', 'Medium')),
+                            'permissions': child_info.get('permissions', []),
+                            'default_flags': child_info.get('default_flags', []),
+                            'access_level': cls.get_user_access_level(user, child_name)
+                            }
+                            category_dict['children'].append(child_dict)
+                
+                hierarchy.append(category_dict)
+        
+        return hierarchy

--- a/grievance_social_protection/admin.py
+++ b/grievance_social_protection/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
 # Register your models here.
-

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -143,13 +143,10 @@ class TicketConfig(AppConfig):
             for key in dict_field:
                 value = dict_field[key]
                 if value in ['', None]:
-                    resolution_times = cfg.get("resolution_times", DEFAULT_TIME_RESOLUTION)
-                    logger.warning(
-                        '"%s" has no value for resolution. The default one is taken as "%s".',
-                        key,
-                        resolution_times
+                    raise ValueError(
+                        f"'{key}' in 'default_resolution' has no value. "
+                        f"Expected format: 'days,hours' (e.g. '{DEFAULT_TIME_RESOLUTION}')."
                     )
-                    dict_field[key] = resolution_times
                 else:
                     cls.__validate_resolution_time_format(value, f"default_resolution[{key}]")
         
@@ -263,10 +260,10 @@ class TicketConfig(AppConfig):
                 # Enhanced dict format with permissions
                 cat_name = item.get('name')
                 if not cat_name:
-                    logger.warning("Category dict must have 'name' field")
-                    return None
+                    raise ValueError("Each category dict in 'grievance_types' must have a 'name' field.")
 
-                full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
+
+                full_name = f"{parent_name} {cat_name}" if parent_name else cat_name
 
                 # Process permissions
                 permissions = item.get('permissions', parent.get('permissions', []))
@@ -290,13 +287,10 @@ class TicketConfig(AppConfig):
                         # Check if child tries to expose fields hidden by parent
                         invalid_fields = child_visible - parent_visible
                         if invalid_fields:
-                            logger.warning(
-                                f"Category '{cat_name}' cannot make fields {invalid_fields} visible - "
-                                f"not in parent's visible_fields. Removing these fields."
+                            raise ValueError(
+                                f"Category '{cat_name}' cannot make fields {invalid_fields} visible — "
+                                f"they are not in parent '{parent_name}' visible_fields."
                             )
-                            # Use intersection to ensure child is subset of parent
-                            visible_fields = list(child_visible & parent_visible)
-                            item['visible_fields'] = visible_fields
                 elif parent.get('visible_fields'):
                     # Inherit parent's visible_fields if not specified
                     visible_fields = parent['visible_fields'].copy()
@@ -369,8 +363,7 @@ class TicketConfig(AppConfig):
                 # Enhanced dict format with permissions
                 flag_name = flag.get('name')
                 if not flag_name:
-                    logger.warning("Flag dict must have 'name' field")
-                    continue
+                    raise ValueError("Each flag dict in 'grievance_flags' must have a 'name' field.")
                 
                 # Process permissions
                 permissions = flag.get('permissions', [])

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from django.apps import AppConfig
 
@@ -61,6 +62,29 @@ class TicketConfig(AppConfig):
     processed_categories = {}
     processed_flags = {}
     unified_resolution_times = {}
+    generated_rights = {}  # Store dynamically generated rights
+    
+    @classmethod
+    def get_all_permissions(cls):
+        """
+        Get all permissions including dynamically generated ones.
+        This method can be used by external systems to get the complete permission list.
+        """
+        all_perms = {}
+        
+        # Start with static permissions from DEFAULT_CFG
+        for key, value in DEFAULT_CFG.items():
+            if key.endswith('_perms'):
+                all_perms[key] = value
+        
+        # Add dynamically generated permissions
+        for right_name, right_id in cls.generated_rights.items():
+            if right_name not in all_perms:
+                all_perms[right_name] = []
+            if right_id not in all_perms[right_name]:
+                all_perms[right_name].append(right_id)
+        
+        return all_perms
 
     def ready(self):
         from core.models import ModuleConfiguration
@@ -72,6 +96,10 @@ class TicketConfig(AppConfig):
         self.__validate_grievance_dict_fields(cfg, 'default_resolution')
         self.__validate_grievance_default_resolution_time(cfg)
         self.__load_config(cfg)
+        # Generate rights only if we're not in a migration
+        if 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
+            from .rights import GrievanceRightsManager
+            GrievanceRightsManager.generate_automatic_rights(self)
 
     @classmethod
     def __validate_grievance_dict_fields(cls, cfg, field_name):
@@ -189,7 +217,8 @@ class TicketConfig(AppConfig):
                     'default_flags': parent_info.get('default_flags', []) if parent_info else [],
                     'resolution_times': parent_info.get('resolution_times') if parent_info else None,
                     'parent': parent_name,
-                    'children': {}
+                    'children': {},
+                    'generated_rights': {}
                 }
                 flat_types.append(full_name)
                 return full_name
@@ -203,8 +232,41 @@ class TicketConfig(AppConfig):
                 
                 full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
                 
-                # Process permissions - list format only, inherit from parent if not specified
+                # Process permissions - handle both dict and list formats
                 permissions = item.get('permissions', parent_info.get('permissions', []) if parent_info else [])
+                # Convert dict format to list format if needed
+                if isinstance(permissions, dict):
+                    permissions = list(permissions.keys())
+                
+                # Process visible_fields with inheritance constraints
+                visible_fields = item.get('visible_fields', [])
+                if visible_fields:
+                    # If visible_fields is defined, ensure restricted_read and read permissions exist
+                    if 'restricted_read' not in permissions:
+                        permissions.append('restricted_read')
+                        logger.info(f"Auto-adding 'restricted_read' permission to category '{cat_name}' due to visible_fields")
+                    if 'read' not in permissions:
+                        permissions.append('read')
+                        logger.info(f"Auto-adding 'read' permission to category '{cat_name}' due to visible_fields")
+                    
+                    # Validate against parent's visible_fields
+                    if parent_info and parent_info.get('visible_fields'):
+                        parent_visible = set(parent_info['visible_fields'])
+                        child_visible = set(visible_fields)
+                        
+                        # Check if child tries to expose fields hidden by parent
+                        invalid_fields = child_visible - parent_visible
+                        if invalid_fields:
+                            logger.warning(
+                                f"Category '{cat_name}' cannot make fields {invalid_fields} visible - "
+                                f"not in parent's visible_fields. Removing these fields."
+                            )
+                            # Use intersection to ensure child is subset of parent
+                            visible_fields = list(child_visible & parent_visible)
+                            item['visible_fields'] = visible_fields
+                elif parent_info and parent_info.get('visible_fields'):
+                    # Inherit parent's visible_fields if not specified
+                    visible_fields = parent_info['visible_fields'].copy()
                 
                 # Inherit from parent if not specified
                 priority = item.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium')
@@ -221,7 +283,8 @@ class TicketConfig(AppConfig):
                     'default_flags': default_flags,
                     'resolution_times': resolution_times,
                     'parent': parent_name,
-                    'children': {}
+                    'children': {},
+                    'generated_rights': {}  # Will be populated by rights generation
                 }
                 
                 processed_categories[full_name] = category_info
@@ -263,7 +326,8 @@ class TicketConfig(AppConfig):
                 # Simple string format (backward compatible)
                 processed_flags[flag] = {
                     'priority': 'Medium',
-                    'permissions': []  # No restrictions - empty list
+                    'permissions': [],  # No restrictions - empty list
+                    'generated_rights': {}
                 }
                 flat_flags.append(flag)
                 
@@ -274,12 +338,16 @@ class TicketConfig(AppConfig):
                     logger.warning("Flag dict must have 'name' field")
                     continue
                 
-                # Process permissions - list format only
+                # Process permissions - handle both dict and list formats
                 permissions = flag.get('permissions', [])
+                # Convert dict format to list format if needed
+                if isinstance(permissions, dict):
+                    permissions = list(permissions.keys())
                 
                 processed_flags[flag_name] = {
                     'priority': flag.get('priority', 'Medium'),
-                    'permissions': permissions
+                    'permissions': permissions,
+                    'generated_rights': {}
                 }
                 flat_flags.append(flag_name)
         
@@ -297,3 +365,4 @@ class TicketConfig(AppConfig):
         for field in cfg:
             if hasattr(TicketConfig, field):
                 setattr(TicketConfig, field, cfg[field])
+    

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import os
 
 from django.apps import AppConfig
 

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -178,28 +178,36 @@ class TicketConfig(AppConfig):
     
     @classmethod
     def __validate_resolution_time_format(cls, value, context=""):
-        """Validate a single resolution time format"""
+        """
+        Validate a single resolution time format.
+
+        Raises:
+            ValueError: If the resolution time format is invalid.
+        """
         if ',' not in value:
-            logger.warning(f"Invalid resolution time format for {context}. "
-                         "Configuration should contain two integers representing days and hours, "
-                         "separated by a comma.")
-            return False
-        
+            raise ValueError(
+                f"Invalid resolution time format for {context}. "
+                "Configuration should contain two integers representing days and hours, "
+                "separated by a comma."
+            )
+
         try:
             parts = value.split(',')
             days = int(parts[0])
             hours = int(parts[1])
-            
-            if 0 <= days < 99 and 0 <= hours < 24:
-                return True
-            else:
-                logger.warning(f"Invalid resolution time values for {context}. "
-                             "Days must be between 0 and 99, and hours must be between 0 and 24.")
-                return False
-        except (ValueError, IndexError):
-            logger.warning(f"Invalid resolution time format for {context}. "
-                         "Expected format: 'days,hours' where both are integers.")
-            return False
+
+            if not (0 <= days < 99 and 0 <= hours < 24):
+                raise ValueError(
+                    f"Invalid resolution time values for {context}. "
+                    "Days must be between 0 and 99, and hours must be between 0 and 24."
+                )
+        except (ValueError, IndexError) as e:
+            if isinstance(e, ValueError) and "Invalid resolution time" in str(e):
+                raise
+            raise ValueError(
+                f"Invalid resolution time format for {context}. "
+                "Expected format: 'days,hours' where both are integers."
+            )
 
     @classmethod
     def __process_unified_categories(cls, cfg):
@@ -214,15 +222,15 @@ class TicketConfig(AppConfig):
         default_grievance_type = cfg.get('default_grievance_type', DEFAULT_GRIEVANCE_TYPE)
         if default_grievance_type:
             # Check if default_grievance_type exists in categories
-            type_exists = False
-            for cat in categories:
-                if isinstance(cat, str) and cat == default_grievance_type:
-                    type_exists = True
-                    break
-                elif isinstance(cat, dict) and cat.get('name') == default_grievance_type:
-                    type_exists = True
-                    break
-            
+            def get_category_name(cat):
+                if isinstance(cat, str):
+                    return cat
+                if isinstance(cat, dict):
+                    return cat.get('name')
+                return None
+
+            type_exists = any(get_category_name(cat) == default_grievance_type for cat in categories)
+
             # If not found, add it with default permissions
             if not type_exists:
                 categories.insert(0, {
@@ -233,52 +241,52 @@ class TicketConfig(AppConfig):
         
         def process_category_item(item, parent_name=None, parent_info=None):
             """Process a single category item (string or dict)"""
+            parent = parent_info or {}
+
             if isinstance(item, str):
                 # Simple string format (backward compatible)
                 full_name = f"{parent_name}|{item}" if parent_name else item
                 processed_categories[full_name] = {
-                    'priority': parent_info.get('priority', 'Medium') if parent_info else 'Medium',
-                    'permissions': parent_info.get('permissions', []) if parent_info else [],  # Inherit from parent
-                    'default_flags': parent_info.get('default_flags', []) if parent_info else [],
-                    'resolution_times': parent_info.get('resolution_times') if parent_info else None,
+                    'priority': parent.get('priority', 'Medium'),
+                    'permissions': parent.get('permissions', []),  # Inherit from parent
+                    'default_flags': parent.get('default_flags', []),
+                    'resolution_times': parent.get('resolution_times'),
+                    'visible_fields': parent.get('visible_fields', []),  # Inherit from parent
                     'parent': parent_name,
                     'children': {},
                     'generated_rights': {}
                 }
                 flat_types.append(full_name)
                 return full_name
-                
+
             elif isinstance(item, dict):
                 # Enhanced dict format with permissions
                 cat_name = item.get('name')
                 if not cat_name:
                     logger.warning("Category dict must have 'name' field")
                     return None
-                
+
                 full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
-                
-                # Process permissions - handle both dict and list formats
-                permissions = item.get('permissions', parent_info.get('permissions', []) if parent_info else [])
-                # Convert dict format to list format if needed
-                if isinstance(permissions, dict):
-                    permissions = list(permissions.keys())
-                
+
+                # Process permissions
+                permissions = item.get('permissions', parent.get('permissions', []))
+
                 # Process visible_fields with inheritance constraints
                 visible_fields = item.get('visible_fields', [])
                 if visible_fields:
                     # If visible_fields is defined, ensure restricted_read and read permissions exist
-                    if 'restricted_read' not in permissions:
-                        permissions.append('restricted_read')
-                        logger.info(f"Auto-adding 'restricted_read' permission to category '{cat_name}' due to visible_fields")
-                    if 'read' not in permissions:
-                        permissions.append('read')
-                        logger.info(f"Auto-adding 'read' permission to category '{cat_name}' due to visible_fields")
-                    
+                    required_permissions = ['restricted_read', 'read']
+                    for perm in required_permissions:
+                        if perm not in permissions:
+                            permissions.append(perm)
+                            logger.info(f"Auto-adding '{perm}' permission to category '{cat_name}' due to visible_fields")
+
                     # Validate against parent's visible_fields
-                    if parent_info and parent_info.get('visible_fields'):
-                        parent_visible = set(parent_info['visible_fields'])
+                    parent_visible_fields = parent.get('visible_fields')
+                    if parent_visible_fields:
+                        parent_visible = set(parent_visible_fields)
                         child_visible = set(visible_fields)
-                        
+
                         # Check if child tries to expose fields hidden by parent
                         invalid_fields = child_visible - parent_visible
                         if invalid_fields:
@@ -289,24 +297,25 @@ class TicketConfig(AppConfig):
                             # Use intersection to ensure child is subset of parent
                             visible_fields = list(child_visible & parent_visible)
                             item['visible_fields'] = visible_fields
-                elif parent_info and parent_info.get('visible_fields'):
+                elif parent.get('visible_fields'):
                     # Inherit parent's visible_fields if not specified
-                    visible_fields = parent_info['visible_fields'].copy()
-                
+                    visible_fields = parent['visible_fields'].copy()
+
                 # Inherit from parent if not specified
-                priority = item.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium')
-                default_flags = item.get('default_flags', parent_info.get('default_flags', []) if parent_info else [])
+                priority = item.get('priority', parent.get('priority', 'Medium'))
+                default_flags = item.get('default_flags', parent.get('default_flags', []))
                 
                 # Handle resolution_times - inherit from parent if not specified
                 resolution_times = item.get('resolution_times')
-                if not resolution_times and parent_info:
-                    resolution_times = parent_info.get('resolution_times')
+                if not resolution_times:
+                    resolution_times = parent.get('resolution_times')
                 
                 category_info = {
                     'priority': priority,
                     'permissions': permissions,
                     'default_flags': default_flags,
                     'resolution_times': resolution_times,
+                    'visible_fields': visible_fields,
                     'parent': parent_name,
                     'children': {},
                     'generated_rights': {}  # Will be populated by rights generation
@@ -363,12 +372,9 @@ class TicketConfig(AppConfig):
                     logger.warning("Flag dict must have 'name' field")
                     continue
                 
-                # Process permissions - handle both dict and list formats
+                # Process permissions
                 permissions = flag.get('permissions', [])
-                # Convert dict format to list format if needed
-                if isinstance(permissions, dict):
-                    permissions = list(permissions.keys())
-                
+
                 processed_flags[flag_name] = {
                     'priority': flag.get('priority', 'Medium'),
                     'permissions': permissions,

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -107,7 +107,7 @@ class TicketConfig(AppConfig):
         if os.environ.get("NO_DATABASE") != "True" and 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
             try:
                 from .rights import GrievanceRightsManager
-                GrievanceRightsManager.generate_automatic_rights(self)
+                GrievanceRightsManager.generate_automatic_rights(TicketConfig)
             except (OperationalError, ProgrammingError):
                 logger.info("Database tables not ready, skipping automatic rights generation.")
 
@@ -252,10 +252,10 @@ class TicketConfig(AppConfig):
                 full_name = f"{parent_name}|{item}" if parent_name else item
                 processed_categories[full_name] = {
                     'priority': parent.get('priority', 'Medium'),
-                    'permissions': parent.get('permissions', []),  # Inherit from parent
-                    'default_flags': parent.get('default_flags', []),
+                    'permissions': list(parent.get('permissions', [])),
+                    'default_flags': list(parent.get('default_flags', [])),
                     'resolution_times': parent.get('resolution_times'),
-                    'visible_fields': parent.get('visible_fields', []),  # Inherit from parent
+                    'visible_fields': list(parent.get('visible_fields', [])),
                     'parent': parent_name,
                     'children': {},
                     'generated_rights': {}
@@ -271,8 +271,8 @@ class TicketConfig(AppConfig):
 
                 full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
 
-                # Process permissions
-                permissions = item.get('permissions', parent.get('permissions', []))
+                # Process permissions — copy to avoid mutating parent's list
+                permissions = list(item.get('permissions', parent.get('permissions', [])))
 
                 # Process visible_fields with inheritance constraints
                 visible_fields = item.get('visible_fields', [])
@@ -304,7 +304,7 @@ class TicketConfig(AppConfig):
 
                 # Inherit from parent if not specified
                 priority = item.get('priority', parent.get('priority', 'Medium'))
-                default_flags = item.get('default_flags', parent.get('default_flags', []))
+                default_flags = list(item.get('default_flags', parent.get('default_flags', [])))
 
                 # Handle resolution_times - inherit from parent if not specified
                 resolution_times = item.get('resolution_times')

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -3,6 +3,7 @@ import sys
 import os
 
 from django.apps import AppConfig
+from django.db import OperationalError, ProgrammingError
 
 logger = logging.getLogger(__name__)
 
@@ -100,10 +101,15 @@ class TicketConfig(AppConfig):
         self.__validate_grievance_dict_fields(cfg, 'default_resolution')
         self.__validate_grievance_default_resolution_time(cfg)
         self.__load_config(cfg)
-        # Generate rights only if we're not in a migration, and NO_DATABASE is set
+        # Generate rights only when the database is available and ready.
+        # Skip during migrations, when NO_DATABASE is set, or when
+        # core tables (django_content_type, auth_permission) don't exist yet.
         if os.environ.get("NO_DATABASE") != "True" and 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
-            from .rights import GrievanceRightsManager
-            GrievanceRightsManager.generate_automatic_rights(self)
+            try:
+                from .rights import GrievanceRightsManager
+                GrievanceRightsManager.generate_automatic_rights(self)
+            except (OperationalError, ProgrammingError):
+                logger.info("Database tables not ready, skipping automatic rights generation.")
 
     @classmethod
     def __validate_grievance_dict_fields(cls, cfg, field_name):

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -61,13 +61,13 @@ class TicketConfig(AppConfig):
     default_grievance_type = DEFAULT_GRIEVANCE_TYPE
     attending_staff_role_ids = []
     default_attending_staff_role_ids = {}
-    
+
     # Processed structures for enhanced configurations
     processed_categories = {}
     processed_flags = {}
     unified_resolution_times = {}
     generated_rights = {}  # Store dynamically generated rights
-    
+
     @classmethod
     def get_all_permissions(cls):
         """
@@ -75,19 +75,19 @@ class TicketConfig(AppConfig):
         This method can be used by external systems to get the complete permission list.
         """
         all_perms = {}
-        
+
         # Start with static permissions from DEFAULT_CFG
         for key, value in DEFAULT_CFG.items():
             if key.endswith('_perms'):
                 all_perms[key] = value
-        
+
         # Add dynamically generated permissions
         for right_name, right_id in cls.generated_rights.items():
             if right_name not in all_perms:
                 all_perms[right_name] = []
             if right_id not in all_perms[right_name]:
                 all_perms[right_name].append(right_id)
-        
+
         return all_perms
 
     def ready(self):
@@ -149,30 +149,30 @@ class TicketConfig(AppConfig):
                     )
                 else:
                     cls.__validate_resolution_time_format(value, f"default_resolution[{key}]")
-        
+
         # Then, validate resolution_times in processed categories
         processed_categories = cfg.get("processed_categories", {})
         for category_name, category_info in processed_categories.items():
             resolution_time = category_info.get('resolution_times')
             if resolution_time:
                 cls.__validate_resolution_time_format(resolution_time, f"category '{category_name}'")
-        
+
         # Build unified resolution times mapping for backward compatibility
         unified_resolution = {}
-        
+
         # Start with legacy default_resolution
         if dict_field:
             unified_resolution.update(dict_field)
-        
+
         # Override/add with category-specific resolution_times
         for category_name, category_info in processed_categories.items():
             resolution_time = category_info.get('resolution_times')
             if resolution_time:
                 unified_resolution[category_name] = resolution_time
-        
+
         # Store the unified mapping back
         cfg['unified_resolution_times'] = unified_resolution
-    
+
     @classmethod
     def __validate_resolution_time_format(cls, value, context=""):
         """
@@ -214,7 +214,7 @@ class TicketConfig(AppConfig):
         categories = cfg.get('grievance_types', [])
         processed_categories = {}
         flat_types = []
-        
+
         # Ensure default_grievance_type is in the categories list
         default_grievance_type = cfg.get('default_grievance_type', DEFAULT_GRIEVANCE_TYPE)
         if default_grievance_type:
@@ -234,8 +234,9 @@ class TicketConfig(AppConfig):
                     'name': default_grievance_type,
                     'permissions': ['read', 'update']
                 })
-                logger.info(f"Added default grievance type '{default_grievance_type}' with permissions ['read', 'update']")
-        
+                logger.info(
+                    f"Added default grievance type '{default_grievance_type}' with permissions ['read', 'update']")
+
         def process_category_item(item, parent_name=None, parent_info=None):
             """Process a single category item (string or dict)"""
             parent = parent_info or {}
@@ -262,7 +263,6 @@ class TicketConfig(AppConfig):
                 if not cat_name:
                     raise ValueError("Each category dict in 'grievance_types' must have a 'name' field.")
 
-
                 full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
 
                 # Process permissions
@@ -276,7 +276,8 @@ class TicketConfig(AppConfig):
                     for perm in required_permissions:
                         if perm not in permissions:
                             permissions.append(perm)
-                            logger.info(f"Auto-adding '{perm}' permission to category '{cat_name}' due to visible_fields")
+                            logger.info(
+                                f"Auto-adding '{perm}' permission to category '{cat_name}' due to visible_fields")
 
                     # Validate against parent's visible_fields
                     parent_visible_fields = parent.get('visible_fields')
@@ -298,12 +299,12 @@ class TicketConfig(AppConfig):
                 # Inherit from parent if not specified
                 priority = item.get('priority', parent.get('priority', 'Medium'))
                 default_flags = item.get('default_flags', parent.get('default_flags', []))
-                
+
                 # Handle resolution_times - inherit from parent if not specified
                 resolution_times = item.get('resolution_times')
                 if not resolution_times:
                     resolution_times = parent.get('resolution_times')
-                
+
                 category_info = {
                     'priority': priority,
                     'permissions': permissions,
@@ -314,10 +315,10 @@ class TicketConfig(AppConfig):
                     'children': {},
                     'generated_rights': {}  # Will be populated by rights generation
                 }
-                
+
                 processed_categories[full_name] = category_info
                 flat_types.append(full_name)
-                
+
                 # Process children recursively
                 children = item.get('children', [])
                 for child in children:
@@ -325,15 +326,15 @@ class TicketConfig(AppConfig):
                     if child_full_name:
                         child_short_name = child_full_name.split('|')[-1]
                         category_info['children'][child_short_name] = child_full_name
-                
+
                 return full_name
-            
+
             return None
-        
+
         # Process all top-level categories
         for category in categories:
             process_category_item(category)
-        
+
         # Store processed data
         cfg['processed_categories'] = processed_categories
         # Update flat list for backward compatibility
@@ -348,7 +349,7 @@ class TicketConfig(AppConfig):
         flags = cfg.get('grievance_flags', [])
         processed_flags = {}
         flat_flags = []
-        
+
         for flag in flags:
             if isinstance(flag, str):
                 # Simple string format (backward compatible)
@@ -358,13 +359,13 @@ class TicketConfig(AppConfig):
                     'generated_rights': {}
                 }
                 flat_flags.append(flag)
-                
+
             elif isinstance(flag, dict):
                 # Enhanced dict format with permissions
                 flag_name = flag.get('name')
                 if not flag_name:
                     raise ValueError("Each flag dict in 'grievance_flags' must have a 'name' field.")
-                
+
                 # Process permissions
                 permissions = flag.get('permissions', [])
 
@@ -374,7 +375,7 @@ class TicketConfig(AppConfig):
                     'generated_rights': {}
                 }
                 flat_flags.append(flag_name)
-        
+
         # Store processed data
         cfg['processed_flags'] = processed_flags
         # Update flat list for backward compatibility
@@ -389,4 +390,3 @@ class TicketConfig(AppConfig):
         for field in cfg:
             if hasattr(TicketConfig, field):
                 setattr(TicketConfig, field, cfg[field])
-    

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -99,8 +99,8 @@ class TicketConfig(AppConfig):
         self.__validate_grievance_dict_fields(cfg, 'default_resolution')
         self.__validate_grievance_default_resolution_time(cfg)
         self.__load_config(cfg)
-        # Generate rights only if we're not in a migration
-        if 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
+        # Generate rights only if we're not in a migration, and NO_DATABASE is set
+        if os.environ.get("NO_DATABASE") != "True" and 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
             from .rights import GrievanceRightsManager
             GrievanceRightsManager.generate_automatic_rights(self)
 

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -56,10 +56,17 @@ class TicketConfig(AppConfig):
     default_resolution = {}
     attending_staff_role_ids = []
     default_attending_staff_role_ids = {}
+    
+    # Processed structures for enhanced configurations
+    processed_categories = {}
+    processed_flags = {}
+    unified_resolution_times = {}
 
     def ready(self):
         from core.models import ModuleConfiguration
         cfg = ModuleConfiguration.get_or_default(MODULE_NAME, DEFAULT_CFG)
+        self.__process_unified_categories(cfg)
+        self.__process_unified_flags(cfg)
         self.__validate_grievance_dict_fields(cfg, 'default_responses')
         self.__validate_grievance_dict_fields(cfg, 'grievance_anonymized_fields')
         self.__validate_grievance_dict_fields(cfg, 'default_resolution')
@@ -91,34 +98,196 @@ class TicketConfig(AppConfig):
 
     @classmethod
     def __validate_grievance_default_resolution_time(cls, cfg):
+        """
+        Validate resolution times from both legacy default_resolution and new category-specific resolution_times.
+        This method also builds a unified resolution times mapping that considers:
+        1. Category-specific resolution_times (from processed_categories)
+        2. Legacy default_resolution configuration
+        3. Global resolution_times fallback
+        """
+        # First, validate legacy default_resolution
         dict_field = cfg.get("default_resolution", {})
-        if not dict_field:
-            return
-        for key in dict_field:
-            value = dict_field[key]
-            if value in ['', None]:
-                resolution_times = cfg.get("resolution_times", DEFAULT_TIME_RESOLUTION)
-                logger.warning(
-                    '"%s" has no value for resolution. The default one is taken as "%s".',
-                    key,
-                    resolution_times
-                )
-                dict_field[key] = resolution_times
-            else:
-                if ',' not in value:
-                    logger.warning("Invalid input. Configuration should contain two integers "
-                                   "representing days and hours, separated by a comma.")
+        if dict_field:
+            for key in dict_field:
+                value = dict_field[key]
+                if value in ['', None]:
+                    resolution_times = cfg.get("resolution_times", DEFAULT_TIME_RESOLUTION)
+                    logger.warning(
+                        '"%s" has no value for resolution. The default one is taken as "%s".',
+                        key,
+                        resolution_times
+                    )
+                    dict_field[key] = resolution_times
                 else:
-                    parts = value.split(',')
-                    # Parse days and hours
-                    days = int(parts[0])
-                    hours = int(parts[1])
-                    # Validate days and hours
-                    if 0 <= days < 99 and 0 <= hours < 24:
-                        logger.info(f"Days: {days}, Hours: {hours}")
-                    else:
-                        logger.warning("Invalid input. Days must be between 0 and 99, "
-                                       "and hours must be between 0 and 24.")
+                    cls.__validate_resolution_time_format(value, f"default_resolution[{key}]")
+        
+        # Then, validate resolution_times in processed categories
+        processed_categories = cfg.get("processed_categories", {})
+        for category_name, category_info in processed_categories.items():
+            resolution_time = category_info.get('resolution_times')
+            if resolution_time:
+                cls.__validate_resolution_time_format(resolution_time, f"category '{category_name}'")
+        
+        # Build unified resolution times mapping for backward compatibility
+        unified_resolution = {}
+        
+        # Start with legacy default_resolution
+        if dict_field:
+            unified_resolution.update(dict_field)
+        
+        # Override/add with category-specific resolution_times
+        for category_name, category_info in processed_categories.items():
+            resolution_time = category_info.get('resolution_times')
+            if resolution_time:
+                unified_resolution[category_name] = resolution_time
+        
+        # Store the unified mapping back
+        cfg['unified_resolution_times'] = unified_resolution
+    
+    @classmethod
+    def __validate_resolution_time_format(cls, value, context=""):
+        """Validate a single resolution time format"""
+        if ',' not in value:
+            logger.warning(f"Invalid resolution time format for {context}. "
+                         "Configuration should contain two integers representing days and hours, "
+                         "separated by a comma.")
+            return False
+        
+        try:
+            parts = value.split(',')
+            days = int(parts[0])
+            hours = int(parts[1])
+            
+            if 0 <= days < 99 and 0 <= hours < 24:
+                return True
+            else:
+                logger.warning(f"Invalid resolution time values for {context}. "
+                             "Days must be between 0 and 99, and hours must be between 0 and 24.")
+                return False
+        except (ValueError, IndexError):
+            logger.warning(f"Invalid resolution time format for {context}. "
+                         "Expected format: 'days,hours' where both are integers.")
+            return False
+
+    @classmethod
+    def __process_unified_categories(cls, cfg):
+        """
+        Process grievance_types configuration supporting both string and dict formats
+        """
+        categories = cfg.get('grievance_types', [])
+        processed_categories = {}
+        flat_types = []
+        
+        def process_category_item(item, parent_name=None, parent_info=None):
+            """Process a single category item (string or dict)"""
+            if isinstance(item, str):
+                # Simple string format (backward compatible)
+                full_name = f"{parent_name}|{item}" if parent_name else item
+                processed_categories[full_name] = {
+                    'priority': parent_info.get('priority', 'Medium') if parent_info else 'Medium',
+                    'permissions': parent_info.get('permissions', []) if parent_info else [],  # Inherit from parent
+                    'default_flags': parent_info.get('default_flags', []) if parent_info else [],
+                    'resolution_times': parent_info.get('resolution_times') if parent_info else None,
+                    'parent': parent_name,
+                    'children': {}
+                }
+                flat_types.append(full_name)
+                return full_name
+                
+            elif isinstance(item, dict):
+                # Enhanced dict format with permissions
+                cat_name = item.get('name')
+                if not cat_name:
+                    logger.warning("Category dict must have 'name' field")
+                    return None
+                
+                full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
+                
+                # Process permissions - list format only, inherit from parent if not specified
+                permissions = item.get('permissions', parent_info.get('permissions', []) if parent_info else [])
+                
+                # Inherit from parent if not specified
+                priority = item.get('priority', parent_info.get('priority', 'Medium') if parent_info else 'Medium')
+                default_flags = item.get('default_flags', parent_info.get('default_flags', []) if parent_info else [])
+                
+                # Handle resolution_times - inherit from parent if not specified
+                resolution_times = item.get('resolution_times')
+                if not resolution_times and parent_info:
+                    resolution_times = parent_info.get('resolution_times')
+                
+                category_info = {
+                    'priority': priority,
+                    'permissions': permissions,
+                    'default_flags': default_flags,
+                    'resolution_times': resolution_times,
+                    'parent': parent_name,
+                    'children': {}
+                }
+                
+                processed_categories[full_name] = category_info
+                flat_types.append(full_name)
+                
+                # Process children recursively
+                children = item.get('children', [])
+                for child in children:
+                    child_full_name = process_category_item(child, full_name, category_info)
+                    if child_full_name:
+                        child_short_name = child_full_name.split('|')[-1]
+                        category_info['children'][child_short_name] = child_full_name
+                
+                return full_name
+            
+            return None
+        
+        # Process all top-level categories
+        for category in categories:
+            process_category_item(category)
+        
+        # Store processed data
+        cfg['processed_categories'] = processed_categories
+        # Update flat list for backward compatibility
+        cfg['grievance_types'] = flat_types
+        TicketConfig.processed_categories = processed_categories
+
+    @classmethod
+    def __process_unified_flags(cls, cfg):
+        """
+        Process grievance_flags configuration supporting both string and dict formats
+        """
+        flags = cfg.get('grievance_flags', [])
+        processed_flags = {}
+        flat_flags = []
+        
+        for flag in flags:
+            if isinstance(flag, str):
+                # Simple string format (backward compatible)
+                processed_flags[flag] = {
+                    'priority': 'Medium',
+                    'permissions': []  # No restrictions - empty list
+                }
+                flat_flags.append(flag)
+                
+            elif isinstance(flag, dict):
+                # Enhanced dict format with permissions
+                flag_name = flag.get('name')
+                if not flag_name:
+                    logger.warning("Flag dict must have 'name' field")
+                    continue
+                
+                # Process permissions - list format only
+                permissions = flag.get('permissions', [])
+                
+                processed_flags[flag_name] = {
+                    'priority': flag.get('priority', 'Medium'),
+                    'permissions': permissions
+                }
+                flat_flags.append(flag_name)
+        
+        # Store processed data
+        cfg['processed_flags'] = processed_flags
+        # Update flat list for backward compatibility
+        cfg['grievance_flags'] = flat_flags
+        TicketConfig.processed_flags = processed_flags
 
     @classmethod
     def __load_config(cls, cfg):

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -14,6 +14,7 @@ DEFAULT_STRING = 'Default'
 DEFAULT_TIME_RESOLUTION = '5,0'
 DEFAULT_GRIEVANCE_TYPE = 'uncategorized'
 VALID_PERMISSION_TYPES = frozenset({'restricted_read', 'read', 'create', 'update', 'delete'})
+CATEGORY_SEPARATOR = ' > '
 
 DEFAULT_CFG = {
     "default_validations_disabled": False,
@@ -251,7 +252,7 @@ class TicketConfig(AppConfig):
 
             if isinstance(item, str):
                 # Simple string format (backward compatible)
-                full_name = f"{parent_name}|{item}" if parent_name else item
+                full_name = f"{parent_name}{CATEGORY_SEPARATOR}{item}" if parent_name else item
                 processed_categories[full_name] = {
                     'priority': parent.get('priority', 'Medium'),
                     'permissions': list(parent.get('permissions', [])),
@@ -271,7 +272,7 @@ class TicketConfig(AppConfig):
                 if not cat_name:
                     raise ValueError("Each category dict in 'grievance_types' must have a 'name' field.")
 
-                full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
+                full_name = f"{parent_name}{CATEGORY_SEPARATOR}{cat_name}" if parent_name else cat_name
 
                 # Process permissions — copy to avoid mutating parent's list
                 permissions = list(item.get('permissions', parent.get('permissions', [])))
@@ -338,7 +339,7 @@ class TicketConfig(AppConfig):
                 for child in children:
                     child_full_name = process_category_item(child, full_name, category_info)
                     if child_full_name:
-                        child_short_name = child_full_name.split('|')[-1]
+                        child_short_name = child_full_name.split(CATEGORY_SEPARATOR)[-1]
                         category_info['children'][child_short_name] = child_full_name
 
                 return full_name

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -263,7 +263,7 @@ class TicketConfig(AppConfig):
                     raise ValueError("Each category dict in 'grievance_types' must have a 'name' field.")
 
 
-                full_name = f"{parent_name} {cat_name}" if parent_name else cat_name
+                full_name = f"{parent_name}|{cat_name}" if parent_name else cat_name
 
                 # Process permissions
                 permissions = item.get('permissions', parent.get('permissions', []))

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -13,6 +13,7 @@ DEFAULT_STRING = 'Default'
 # CRON timedelta: {days},{hours}
 DEFAULT_TIME_RESOLUTION = '5,0'
 DEFAULT_GRIEVANCE_TYPE = 'uncategorized'
+VALID_PERMISSION_TYPES = frozenset({'restricted_read', 'read', 'create', 'update', 'delete'})
 
 DEFAULT_CFG = {
     "default_validations_disabled": False,
@@ -234,7 +235,8 @@ class TicketConfig(AppConfig):
 
             type_exists = any(get_category_name(cat) == default_grievance_type for cat in categories)
 
-            # If not found, add it with default permissions
+            # If not found, add it with default permissions so uncategorized
+            # tickets are subject to access control like all other categories.
             if not type_exists:
                 categories.insert(0, {
                     'name': default_grievance_type,
@@ -273,6 +275,12 @@ class TicketConfig(AppConfig):
 
                 # Process permissions — copy to avoid mutating parent's list
                 permissions = list(item.get('permissions', parent.get('permissions', [])))
+                invalid = set(permissions) - VALID_PERMISSION_TYPES
+                if invalid:
+                    raise ValueError(
+                        f"Category '{cat_name}' has invalid permission types: {invalid}. "
+                        f"Allowed: {sorted(VALID_PERMISSION_TYPES)}"
+                    )
 
                 # Process visible_fields with inheritance constraints
                 visible_fields = item.get('visible_fields', [])
@@ -374,6 +382,12 @@ class TicketConfig(AppConfig):
 
                 # Process permissions
                 permissions = flag.get('permissions', [])
+                invalid = set(permissions) - VALID_PERMISSION_TYPES
+                if invalid:
+                    raise ValueError(
+                        f"Flag '{flag_name}' has invalid permission types: {invalid}. "
+                        f"Allowed: {sorted(VALID_PERMISSION_TYPES)}"
+                    )
 
                 processed_flags[flag_name] = {
                     'priority': flag.get('priority', 'Medium'),

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -10,9 +10,11 @@ MODULE_NAME = "grievance_social_protection"
 DEFAULT_STRING = 'Default'
 # CRON timedelta: {days},{hours}
 DEFAULT_TIME_RESOLUTION = '5,0'
+DEFAULT_GRIEVANCE_TYPE = 'uncategorized'
 
 DEFAULT_CFG = {
     "default_validations_disabled": False,
+    "default_grievance_type": DEFAULT_GRIEVANCE_TYPE,
     "gql_query_tickets_perms": ["127000"],
     "gql_query_comments_perms": ["127004"],
     "gql_mutation_create_tickets_perms": ["127001"],
@@ -55,6 +57,7 @@ class TicketConfig(AppConfig):
     grievance_anonymized_fields = {}
     resolution_times = {}
     default_resolution = {}
+    default_grievance_type = DEFAULT_GRIEVANCE_TYPE
     attending_staff_role_ids = []
     default_attending_staff_role_ids = {}
     
@@ -205,6 +208,27 @@ class TicketConfig(AppConfig):
         categories = cfg.get('grievance_types', [])
         processed_categories = {}
         flat_types = []
+        
+        # Ensure default_grievance_type is in the categories list
+        default_grievance_type = cfg.get('default_grievance_type', DEFAULT_GRIEVANCE_TYPE)
+        if default_grievance_type:
+            # Check if default_grievance_type exists in categories
+            type_exists = False
+            for cat in categories:
+                if isinstance(cat, str) and cat == default_grievance_type:
+                    type_exists = True
+                    break
+                elif isinstance(cat, dict) and cat.get('name') == default_grievance_type:
+                    type_exists = True
+                    break
+            
+            # If not found, add it with default permissions
+            if not type_exists:
+                categories.insert(0, {
+                    'name': default_grievance_type,
+                    'permissions': ['read', 'update']
+                })
+                logger.info(f"Added default grievance type '{default_grievance_type}' with permissions ['read', 'update']")
         
         def process_category_item(item, parent_name=None, parent_info=None):
             """Process a single category item (string or dict)"""

--- a/grievance_social_protection/gql_mutations.py
+++ b/grievance_social_protection/gql_mutations.py
@@ -31,7 +31,7 @@ class CreateTicketInputType(OpenIMISMutation.Input):
     status = graphene.Field(TicketStatusEnum, required=False)
     priority = graphene.String(required=False)
     due_date = graphene.Date(required=False)
-    category = graphene.String(required=True)
+    category = graphene.String(required=False)
     flags = graphene.String(required=False)
     channel = graphene.String(required=False)
     resolution = graphene.String(required=False)

--- a/grievance_social_protection/gql_mutations.py
+++ b/grievance_social_protection/gql_mutations.py
@@ -219,7 +219,7 @@ class ReopenTicketMutation(BaseHistoryModelUpdateMutationMixin, BaseMutation):
         if client_mutation_id:
             ticket_id = data.get('id')
             ticket = Ticket.objects.get(id=ticket_id)
-            TicketMutation.object_mutated(user, client_mutation_id=client_mutation_id, Ticket=ticket)
+            TicketMutation.object_mutated(user, client_mutation_id=client_mutation_id, ticket=ticket)
 
         if not response['success']:
             return response

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -72,11 +72,10 @@ class TicketFilterSet(django_filters.FilterSet):
             # Skip empty values (matches django-filter base behavior)
             if value in EMPTY_VALUES:
                 continue
-            base_field = filter_obj.field_name.split('__')[0]
-            if base_field in restricted:
+            if name in restricted:
                 logger.info(
                     "User %s blocked from filtering on restricted field '%s'",
-                    getattr(user, 'username', '?'), base_field
+                    getattr(user, 'username', '?'), name
                 )
                 continue
             queryset = filter_obj.filter(queryset, value)

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -49,56 +49,46 @@ class TicketGQLType(DjangoObjectType):
     def _should_restrict_field(field_name, root, info):
         """
         Check if a field should be restricted based on user's access level and visible_fields configuration.
+
+        Access level is determined by both category and flags (most restrictive wins).
+        Visible fields configuration is per-category only.
         """
-        
         user = info.context.user
-        access_level = GrievanceAccessControl.get_user_access_level(user, root.category, root.flags)
-        
-        # Full access - no restrictions
-        if access_level in ['full', 'read']:
-            return False
-        
-        # No access - restrict everything
-        if access_level == 'none':
+        visible_fields = GrievanceAccessControl.get_visible_fields(user, root.category)
+
+        # None means unrestricted access based on category - but check flags too
+        if visible_fields is None:
+            # Double-check with flags included for full access determination
+            access_level = GrievanceAccessControl.get_user_access_level(user, root.category, root.flags)
+            return access_level not in (GrievanceAccessControl.ACCESS_FULL, GrievanceAccessControl.ACCESS_READ)
+
+        # Empty list means no access
+        if not visible_fields:
             return True
-        
-        # Restricted access - check visible_fields
-        if access_level == 'restricted':
-            visible_fields = GrievanceAccessControl.get_visible_fields(user, root.category)
-            # If visible_fields is None, use default behavior (restrict sensitive fields)
-            if visible_fields is None:
-                # Default restricted fields when no visible_fields configured
-                default_hidden = ['description', 'resolution', 'reporter_id', 'channel', 
-                                'attending_staff', 'json_ext', 'category', 'flags', 'title']
-                return field_name in default_hidden
-            # If visible_fields is defined, only show fields in the list
-            return field_name not in visible_fields
-        
-        return True
+
+        # Check if field is in visible list
+        return field_name not in visible_fields
     
     @staticmethod
     def resolve_reporter_type(root, info):
         check_ticket_perms(info)
-        # Check access level
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide for restricted access
+        # Use _should_restrict_field for consistent access control
+        if TicketGQLType._should_restrict_field('reporter_type', root, info):
+            return None
         return root.reporter_type.id if root.reporter_type else None
 
     @staticmethod
     def resolve_reporter_type_name(root, info):
         check_ticket_perms(info)
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide for restricted access
+        if TicketGQLType._should_restrict_field('reporter_type', root, info):
+            return None
         return root.reporter_type.name if root.reporter_type else None
 
     @staticmethod
     def resolve_reporter(root, info):
         check_ticket_perms(info)
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide reporter details for restricted access
+        if TicketGQLType._should_restrict_field('reporter', root, info):
+            return None
         return model_obj_to_json(root.reporter) if root.reporter else None
 
     @staticmethod
@@ -109,9 +99,8 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_first_name(root, info):
         check_ticket_perms(info)
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide personal info for restricted access
+        if TicketGQLType._should_restrict_field('reporter_first_name', root, info):
+            return "[Restricted]"
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -128,9 +117,8 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_last_name(root, info):
         check_ticket_perms(info)
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide personal info for restricted access
+        if TicketGQLType._should_restrict_field('reporter_last_name', root, info):
+            return "[Restricted]"
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -147,9 +135,8 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_dob(root, info):
         check_ticket_perms(info)
-        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
-        if access_level in ['none', 'restricted']:
-            return None  # Hide personal info for restricted access
+        if TicketGQLType._should_restrict_field('reporter_dob', root, info):
+            return None
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -166,25 +153,25 @@ class TicketGQLType(DjangoObjectType):
     def resolve_description(self, info):
         """Return [Restricted] for restricted access"""
         if TicketGQLType._should_restrict_field('description', self, info):
-            return "[Restricted]" if self.description else None
+            return "[Restricted]"
         return self.description
-    
+
     def resolve_resolution(self, info):
         """Return [Restricted] for restricted access"""
         if TicketGQLType._should_restrict_field('resolution', self, info):
-            return "[Restricted]" if self.resolution else None
+            return "[Restricted]"
         return self.resolution
-    
+
     def resolve_reporter_id(self, info):
         """Hide reporter_id for restricted access"""
         if TicketGQLType._should_restrict_field('reporter_id', self, info):
             return None
         return self.reporter_id
-    
+
     def resolve_channel(self, info):
         """Return [Restricted] for restricted access"""
         if TicketGQLType._should_restrict_field('channel', self, info):
-            return "[Restricted]" if self.channel else None
+            return "[Restricted]"
         return self.channel
     
     def resolve_attending_staff(self, info):

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -72,10 +72,10 @@ class TicketFilterSet(django_filters.FilterSet):
             # Skip empty values (matches django-filter base behavior)
             if value in EMPTY_VALUES:
                 continue
-            if name in restricted:
+            if filter_obj.field_name in restricted:
                 logger.info(
                     "User %s blocked from filtering on restricted field '%s'",
-                    getattr(user, 'username', '?'), name
+                    getattr(user, 'username', '?'), filter_obj.field_name
                 )
                 continue
             queryset = filter_obj.filter(queryset, value)
@@ -538,7 +538,10 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
         ]
 
     def resolve_grievance_default_resolutions_by_category(self, info):
+        resolution_mapping = getattr(
+            TicketConfig, 'unified_resolution_times', TicketConfig.default_resolution
+        )
         return [
             ResolutionTimesByCategoryGQLType(category=category_key, resolution_time=resolution_time)
-            for category_key, resolution_time in TicketConfig.default_resolution.items()
+            for category_key, resolution_time in resolution_mapping.items()
         ]

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -142,7 +142,7 @@ class TicketGQLType(DjangoObjectType):
     reporter_first_name = graphene.String()
     reporter_last_name = graphene.String()
     reporter_dob = graphene.String()
-    
+
     # Access level for this ticket based on user's rights
     access_level = graphene.String()
 
@@ -150,7 +150,7 @@ class TicketGQLType(DjangoObjectType):
     def resolve_access_level(root, info):
         user = info.context.user
         return GrievanceAccessControl.get_user_access_level(user, root.category, root.flags)
-    
+
     @staticmethod
     def _should_restrict_field(field_name, root, info):
         """
@@ -324,7 +324,6 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_due_date(root, info):
         return TicketGQLType._restricted_resolve(root, info, 'due_date', restricted_value=None)
-    
 
     class Meta:
         model = Ticket
@@ -496,12 +495,12 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
 
     def resolve_grievance_channels(self, info):
         return TicketConfig.grievance_channels
-    
+
     def resolve_grievance_categories_hierarchical(self, info):
         """Return hierarchical category structure with access control"""
         user = info.context.user
         hierarchy = GrievanceAccessControl.get_category_hierarchy(user)
-        
+
         def build_gql_category(cat_dict):
             """Convert dict to GQL type"""
             children = [build_gql_category(child) for child in cat_dict.get('children', [])]
@@ -513,16 +512,16 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
                 default_flags=cat_dict.get('default_flags', []),
                 children=children
             )
-        
+
         return [build_gql_category(cat) for cat in hierarchy]
-    
+
     def resolve_grievance_flags_detailed(self, info):
         """Return detailed flag information with access control"""
-        
+
         user = info.context.user
         accessible_flags = GrievanceAccessControl.get_accessible_flags(user)
         processed_flags = getattr(TicketConfig, 'processed_flags', {})
-        
+
         flags = []
         for flag_name in accessible_flags:
             flag_info = processed_flags.get(flag_name, {})
@@ -531,9 +530,9 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
                 priority=flag_info.get('priority', 'Medium'),
                 permissions=flag_info.get('permissions', {})
             ))
-        
+
         return flags
-    
+
     def resolve_grievance_category_staff_roles(self, info):
         return [
             AttendingStaffRoleGQLType(category=category_key, role_ids=role_ids)

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -479,6 +479,7 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
     grievance_default_resolutions_by_category = graphene.List(ResolutionTimesByCategoryGQLType)
     # Enhanced fields
     grievance_categories_hierarchical = graphene.List(GrievanceCategoryGQLType)
+    grievance_categories_json = graphene.JSONString()
     grievance_flags_detailed = graphene.List(GrievanceFlagGQLType)
 
     def resolve_grievance_types(self, info):
@@ -493,6 +494,11 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
 
     def resolve_grievance_channels(self, info):
         return TicketConfig.grievance_channels
+
+    def resolve_grievance_categories_json(self, info):
+        """Return full category hierarchy as JSON — no depth limitation"""
+        user = info.context.user
+        return GrievanceAccessControl.get_category_hierarchy(user)
 
     def resolve_grievance_categories_hierarchical(self, info):
         """Return hierarchical category structure with access control"""

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -474,16 +474,6 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
         
         return flags
     
-    def resolve_accessible_categories(self, info):
-        """Return flat list of accessible categories for create operations"""
-        user = info.context.user
-        return GrievanceAccessControl.get_accessible_categories(user)
-    
-    def resolve_accessible_flags(self, info):
-        """Return flat list of accessible flags for use operations"""
-        user = info.context.user
-        return GrievanceAccessControl.get_accessible_flags(user)
-
     def resolve_grievance_category_staff_roles(self, info):
         category_staff_role_list = []
         for category_key, role_ids in TicketConfig.default_attending_staff_role_ids.items():

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from core.gql_queries import UserGQLType
 from .apps import TicketConfig
 from .models import Ticket, Comment
+from .access_control import GrievanceAccessControl
 
 from core import prefix_filterset, ExtendedConnection
 from .util import model_obj_to_json
@@ -26,7 +27,6 @@ def check_comment_perms(info):
 
 
 class TicketGQLType(DjangoObjectType):
-    # TODO on resolve check filters and remove anonymized so user can't fetch ticket using last_name if not visible
     client_mutation_id = graphene.String()
     reporter = graphene.JSONString()
     reporter_type = graphene.Int()
@@ -36,20 +36,69 @@ class TicketGQLType(DjangoObjectType):
     reporter_first_name = graphene.String()
     reporter_last_name = graphene.String()
     reporter_dob = graphene.String()
+    
+    # Access level for this ticket based on user's rights
+    access_level = graphene.String()
 
+    @staticmethod
+    def resolve_access_level(root, info):
+        user = info.context.user
+        return GrievanceAccessControl.get_user_access_level(user, root.category, root.flags)
+    
+    @staticmethod
+    def _should_restrict_field(field_name, root, info):
+        """
+        Check if a field should be restricted based on user's access level and visible_fields configuration.
+        """
+        
+        user = info.context.user
+        access_level = GrievanceAccessControl.get_user_access_level(user, root.category, root.flags)
+        
+        # Full access - no restrictions
+        if access_level in ['full', 'read']:
+            return False
+        
+        # No access - restrict everything
+        if access_level == 'none':
+            return True
+        
+        # Restricted access - check visible_fields
+        if access_level == 'restricted':
+            visible_fields = GrievanceAccessControl.get_visible_fields(user, root.category)
+            # If visible_fields is None, use default behavior (restrict sensitive fields)
+            if visible_fields is None:
+                # Default restricted fields when no visible_fields configured
+                default_hidden = ['description', 'resolution', 'reporter_id', 'channel', 
+                                'attending_staff', 'json_ext', 'category', 'flags', 'title']
+                return field_name in default_hidden
+            # If visible_fields is defined, only show fields in the list
+            return field_name not in visible_fields
+        
+        return True
+    
     @staticmethod
     def resolve_reporter_type(root, info):
         check_ticket_perms(info)
+        # Check access level
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide for restricted access
         return root.reporter_type.id if root.reporter_type else None
 
     @staticmethod
     def resolve_reporter_type_name(root, info):
         check_ticket_perms(info)
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide for restricted access
         return root.reporter_type.name if root.reporter_type else None
 
     @staticmethod
     def resolve_reporter(root, info):
         check_ticket_perms(info)
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide reporter details for restricted access
         return model_obj_to_json(root.reporter) if root.reporter else None
 
     @staticmethod
@@ -60,6 +109,9 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_first_name(root, info):
         check_ticket_perms(info)
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide personal info for restricted access
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -76,6 +128,9 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_last_name(root, info):
         check_ticket_perms(info)
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide personal info for restricted access
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -92,6 +147,9 @@ class TicketGQLType(DjangoObjectType):
     @staticmethod
     def resolve_reporter_dob(root, info):
         check_ticket_perms(info)
+        access_level = GrievanceAccessControl.get_user_access_level(info.context.user, root.category, root.flags)
+        if access_level in ['none', 'restricted']:
+            return None  # Hide personal info for restricted access
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -105,9 +163,97 @@ class TicketGQLType(DjangoObjectType):
                         return None
         return None
 
+    def resolve_description(self, info):
+        """Return [Restricted] for restricted access"""
+        if TicketGQLType._should_restrict_field('description', self, info):
+            return "[Restricted]" if self.description else None
+        return self.description
+    
+    def resolve_resolution(self, info):
+        """Return [Restricted] for restricted access"""
+        if TicketGQLType._should_restrict_field('resolution', self, info):
+            return "[Restricted]" if self.resolution else None
+        return self.resolution
+    
+    def resolve_reporter_id(self, info):
+        """Hide reporter_id for restricted access"""
+        if TicketGQLType._should_restrict_field('reporter_id', self, info):
+            return None
+        return self.reporter_id
+    
+    def resolve_channel(self, info):
+        """Return [Restricted] for restricted access"""
+        if TicketGQLType._should_restrict_field('channel', self, info):
+            return "[Restricted]" if self.channel else None
+        return self.channel
+    
+    def resolve_attending_staff(self, info):
+        """Hide attending_staff for restricted access"""
+        if TicketGQLType._should_restrict_field('attending_staff', self, info):
+            return None
+        return self.attending_staff
+    
+    def resolve_json_ext(self, info):
+        """Hide json_ext for restricted access"""
+        if TicketGQLType._should_restrict_field('json_ext', self, info):
+            return None
+        return self.json_ext
+    
+    def resolve_category(self, info):
+        """Return category value based on visible_fields"""
+        if TicketGQLType._should_restrict_field('category', self, info):
+            return "[Restricted]" if self.category else None
+        return self.category
+    
+    def resolve_flags(self, info):
+        """Return flags value based on visible_fields"""
+        if TicketGQLType._should_restrict_field('flags', self, info):
+            return "[Restricted]" if self.flags else None
+        return self.flags
+    
+    def resolve_title(self, info):
+        """Return title value based on visible_fields"""
+        if TicketGQLType._should_restrict_field('title', self, info):
+            return "[Restricted]" if self.title else None
+        return self.title
+    
+    def resolve_status(self, info):
+        """Status is usually visible for restricted users"""
+        if TicketGQLType._should_restrict_field('status', self, info):
+            return None
+        return self.status
+    
+    def resolve_priority(self, info):
+        """Priority is usually visible for restricted users"""
+        if TicketGQLType._should_restrict_field('priority', self, info):
+            return None
+        return self.priority
+    
+    def resolve_date_created(self, info):
+        """Date created is usually visible for restricted users"""
+        if TicketGQLType._should_restrict_field('date_created', self, info):
+            return None
+        return self.date_created
+    
+    def resolve_date_of_incident(self, info):
+        """Date of incident might be restricted"""
+        if TicketGQLType._should_restrict_field('date_of_incident', self, info):
+            return None
+        return self.date_of_incident
+    
+    def resolve_due_date(self, info):
+        """Due date might be restricted"""
+        if TicketGQLType._should_restrict_field('due_date', self, info):
+            return None
+        return self.due_date
+    
+
     class Meta:
         model = Ticket
         interfaces = (graphene.relay.Node,)
+        # SECURITY NOTE: These filter fields are static and don't respect field-level permissions.
+        # Users with restricted access can still filter by these fields even if they can't see the values.
+        # TODO: Implement dynamic filter removal based on user's visible_fields configuration
         filter_fields = {
             "id": ["exact", "isnull"],
             "version": ["exact"],
@@ -280,13 +426,11 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
 
     def resolve_grievance_types(self, info):
         # Return accessible categories in flat format for backward compatibility
-        from .access_control import GrievanceAccessControl
         user = info.context.user
         return GrievanceAccessControl.get_accessible_categories(user)
 
     def resolve_grievance_flags(self, info):
         # Return accessible flags
-        from .access_control import GrievanceAccessControl
         user = info.context.user
         return GrievanceAccessControl.get_accessible_flags(user)
 
@@ -295,7 +439,6 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
     
     def resolve_grievance_categories_hierarchical(self, info):
         """Return hierarchical category structure with access control"""
-        from .access_control import GrievanceAccessControl
         user = info.context.user
         hierarchy = GrievanceAccessControl.get_category_hierarchy(user)
         
@@ -315,8 +458,6 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
     
     def resolve_grievance_flags_detailed(self, info):
         """Return detailed flag information with access control"""
-        from .access_control import GrievanceAccessControl
-        from .apps import TicketConfig
         
         user = info.context.user
         accessible_flags = GrievanceAccessControl.get_accessible_flags(user)
@@ -335,13 +476,11 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
     
     def resolve_accessible_categories(self, info):
         """Return flat list of accessible categories for create operations"""
-        from .access_control import GrievanceAccessControl
         user = info.context.user
         return GrievanceAccessControl.get_accessible_categories(user)
     
     def resolve_accessible_flags(self, info):
         """Return flat list of accessible flags for use operations"""
-        from .access_control import GrievanceAccessControl
         user = info.context.user
         return GrievanceAccessControl.get_accessible_flags(user)
 

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -2,6 +2,7 @@ import logging
 
 import graphene
 import django_filters
+from django_filters.constants import EMPTY_VALUES
 from django.db import models
 from graphene import ObjectType
 from graphene_django import DjangoObjectType
@@ -68,8 +69,8 @@ class TicketFilterSet(django_filters.FilterSet):
             filter_obj = self.filters.get(name)
             if not filter_obj:
                 continue
-            # Skip null/empty values (matches django-filter base behavior)
-            if value is None:
+            # Skip empty values (matches django-filter base behavior)
+            if value in EMPTY_VALUES:
                 continue
             base_field = filter_obj.field_name.split('__')[0]
             if base_field in restricted:
@@ -480,8 +481,6 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
     # Enhanced fields
     grievance_categories_hierarchical = graphene.List(GrievanceCategoryGQLType)
     grievance_flags_detailed = graphene.List(GrievanceFlagGQLType)
-    accessible_categories = graphene.List(graphene.String)
-    accessible_flags = graphene.List(graphene.String)
 
     def resolve_grievance_types(self, info):
         # Return accessible categories in flat format for backward compatibility

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -1,4 +1,8 @@
+import logging
+
 import graphene
+import django_filters
+from django.db import models
 from graphene import ObjectType
 from graphene_django import DjangoObjectType
 from django.contrib.contenttypes.models import ContentType
@@ -14,7 +18,107 @@ from core import prefix_filterset, ExtendedConnection
 from .util import model_obj_to_json
 from .validations import user_associated_with_ticket
 
+logger = logging.getLogger(__name__)
+
 RESTRICTED_VALUE = "[Restricted]"
+
+# Fields that are always safe to filter on regardless of access level
+_ALWAYS_FILTERABLE = frozenset({'id', 'version'})
+
+# Shared filter field definitions used by TicketFilterSet and CommentGQLType
+TICKET_FILTER_FIELDS = {
+    "id": ["exact", "isnull"],
+    "version": ["exact"],
+    "key": ["exact", "istartswith", "icontains", "iexact"],
+    "code": ["exact", "istartswith", "icontains", "iexact"],
+    "title": ["exact", "istartswith", "icontains", "iexact"],
+    "description": ["exact", "istartswith", "icontains", "iexact"],
+    "status": ["exact", "istartswith", "icontains", "iexact"],
+    "priority": ["exact", "istartswith", "icontains", "iexact"],
+    "category": ["exact", "istartswith", "icontains", "iexact"],
+    "flags": ["exact", "istartswith", "icontains", "iexact"],
+    "channel": ["exact", "istartswith", "icontains", "iexact"],
+    "resolution": ["exact", "istartswith", "icontains", "iexact"],
+    'reporter_id': ["exact"],
+    "due_date": ["exact", "istartswith", "icontains", "iexact"],
+    "date_of_incident": ["exact", "istartswith", "icontains", "iexact"],
+    "date_created": ["exact", "istartswith", "icontains", "iexact"],
+    **prefix_filterset("attending_staff__", UserGQLType._meta.filter_fields),
+}
+
+
+class TicketFilterSet(django_filters.FilterSet):
+    """Custom FilterSet that enforces field-level filter restrictions.
+
+    Users with restricted_read access to a category can only filter on
+    fields listed in their visible_fields configuration. This prevents
+    information inference attacks via filter parameters.
+    """
+
+    class Meta:
+        model = Ticket
+        fields = TICKET_FILTER_FIELDS
+
+    def filter_queryset(self, queryset):
+        """Override to skip filters on fields the user cannot see."""
+        user = getattr(self.request, 'user', None) if self.request else None
+        restricted = self._get_restricted_fields(user)
+
+        for name, value in self.form.cleaned_data.items():
+            filter_obj = self.filters.get(name)
+            if not filter_obj:
+                continue
+            # Skip null/empty values (matches django-filter base behavior)
+            if value is None:
+                continue
+            base_field = filter_obj.field_name.split('__')[0]
+            if base_field in restricted:
+                logger.info(
+                    "User %s blocked from filtering on restricted field '%s'",
+                    getattr(user, 'username', '?'), base_field
+                )
+                continue
+            queryset = filter_obj.filter(queryset, value)
+            assert isinstance(queryset, models.QuerySet), (
+                "Expected '%s.%s' to return a QuerySet, but got a %s instead."
+                % (type(self).__name__, name, type(queryset).__name__)
+            )
+        return queryset
+
+    @staticmethod
+    def _get_restricted_fields(user):
+        """Get fields that should not be filterable for this user.
+
+        If the user has restricted_read access to ANY accessible category,
+        fields not in that category's visible_fields are blocked from filtering.
+        Because restrictions are accumulated across all categories via set union,
+        a field blocked in any one restricted category is blocked everywhere.
+
+        Anonymous/unauthenticated users are blocked from filtering on all fields
+        as defense-in-depth (check_ticket_perms should block them upstream).
+        """
+        if not user or user.is_anonymous:
+            # Block all filterable fields — anonymous users should not reach
+            # this point (check_ticket_perms gates upstream), but if they do,
+            # deny all filtering rather than allowing it.
+            return set(TicketFilterSet.Meta.fields.keys()) - _ALWAYS_FILTERABLE
+
+        restricted = set()
+        processed_categories = TicketConfig.processed_categories
+
+        if not processed_categories:
+            return restricted
+
+        all_filterable = set(TicketFilterSet.Meta.fields.keys()) - _ALWAYS_FILTERABLE
+
+        for cat_name in processed_categories:
+            visible_fields = GrievanceAccessControl.get_visible_fields(user, cat_name)
+            # visible_fields is None for full/read access, [] for no access,
+            # or a list of field names for restricted access
+            if visible_fields is not None and visible_fields:
+                restricted |= all_filterable - set(visible_fields)
+
+        return restricted
 
 
 def check_ticket_perms(info):
@@ -225,28 +329,10 @@ class TicketGQLType(DjangoObjectType):
     class Meta:
         model = Ticket
         interfaces = (graphene.relay.Node,)
-        # SECURITY NOTE: These filter fields are static and don't respect field-level permissions.
-        # Users with restricted access can still filter by these fields even if they can't see the values.
-        # TODO: Implement dynamic filter removal based on user's visible_fields configuration
-        filter_fields = {
-            "id": ["exact", "isnull"],
-            "version": ["exact"],
-            "key": ["exact", "istartswith", "icontains", "iexact"],
-            "code": ["exact", "istartswith", "icontains", "iexact"],
-            "title": ["exact", "istartswith", "icontains", "iexact"],
-            "description": ["exact", "istartswith", "icontains", "iexact"],
-            "status": ["exact", "istartswith", "icontains", "iexact"],
-            "priority": ["exact", "istartswith", "icontains", "iexact"],
-            "category": ["exact", "istartswith", "icontains", "iexact"],
-            "flags": ["exact", "istartswith", "icontains", "iexact"],
-            "channel": ["exact", "istartswith", "icontains", "iexact"],
-            "resolution": ["exact", "istartswith", "icontains", "iexact"],
-            'reporter_id': ["exact"],
-            "due_date": ["exact", "istartswith", "icontains", "iexact"],
-            "date_of_incident": ["exact", "istartswith", "icontains", "iexact"],
-            "date_created": ["exact", "istartswith", "icontains", "iexact"],
-            **prefix_filterset("attending_staff__", UserGQLType._meta.filter_fields),
-        }
+        # TicketFilterSet enforces field-level filter restrictions:
+        # users with restricted_read access cannot filter on fields
+        # outside their visible_fields configuration.
+        filterset_class = TicketFilterSet
 
         connection_class = ExtendedConnection
 
@@ -336,7 +422,7 @@ class CommentGQLType(DjangoObjectType):
             "comment": ["exact", "istartswith", "icontains", "iexact"],
             "date_created": ["exact", "istartswith", "icontains", "iexact"],
             "is_resolution": ["exact"],
-            **prefix_filterset("ticket__", TicketGQLType._meta.filter_fields),
+            **prefix_filterset("ticket__", TICKET_FILTER_FIELDS),
         }
 
         connection_class = ExtendedConnection
@@ -351,7 +437,7 @@ class CommentGQLType(DjangoObjectType):
 #             "filename": ["exact", "icontains"],
 #             "mime_type": ["exact", "icontains"],
 #             "url": ["exact", "icontains"],
-#             **prefix_filterset("ticket__", TicketGQLType._meta.filter_fields),
+#             **prefix_filterset("ticket__", TICKET_FILTER_FIELDS),
 #         }
 #         connection_class = ExtendedConnection
 #

--- a/grievance_social_protection/gql_queries.py
+++ b/grievance_social_protection/gql_queries.py
@@ -14,6 +14,8 @@ from core import prefix_filterset, ExtendedConnection
 from .util import model_obj_to_json
 from .validations import user_associated_with_ticket
 
+RESTRICTED_VALUE = "[Restricted]"
+
 
 def check_ticket_perms(info):
     if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):
@@ -68,7 +70,20 @@ class TicketGQLType(DjangoObjectType):
 
         # Check if field is in visible list
         return field_name not in visible_fields
-    
+
+    @staticmethod
+    def _restricted_resolve(root, info, field_name, restricted_value=RESTRICTED_VALUE, preserve_none=False):
+        """Return restricted_value when field is restricted, otherwise return the field value.
+
+        When preserve_none is True, returns None instead of restricted_value if the
+        underlying field is falsy (avoids revealing that a value exists).
+        """
+        if TicketGQLType._should_restrict_field(field_name, root, info):
+            if preserve_none and not getattr(root, field_name):
+                return None
+            return restricted_value
+        return getattr(root, field_name)
+
     @staticmethod
     def resolve_reporter_type(root, info):
         check_ticket_perms(info)
@@ -100,7 +115,7 @@ class TicketGQLType(DjangoObjectType):
     def resolve_reporter_first_name(root, info):
         check_ticket_perms(info)
         if TicketGQLType._should_restrict_field('reporter_first_name', root, info):
-            return "[Restricted]"
+            return RESTRICTED_VALUE
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -118,7 +133,7 @@ class TicketGQLType(DjangoObjectType):
     def resolve_reporter_last_name(root, info):
         check_ticket_perms(info)
         if TicketGQLType._should_restrict_field('reporter_last_name', root, info):
-            return "[Restricted]"
+            return RESTRICTED_VALUE
         if root.reporter_type:
             content_type = ContentType.objects.get_for_model(root.reporter_type.model_class())
             if content_type:
@@ -150,89 +165,61 @@ class TicketGQLType(DjangoObjectType):
                         return None
         return None
 
-    def resolve_description(self, info):
-        """Return [Restricted] for restricted access"""
-        if TicketGQLType._should_restrict_field('description', self, info):
-            return "[Restricted]"
-        return self.description
+    @staticmethod
+    def resolve_description(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'description')
 
-    def resolve_resolution(self, info):
-        """Return [Restricted] for restricted access"""
-        if TicketGQLType._should_restrict_field('resolution', self, info):
-            return "[Restricted]"
-        return self.resolution
+    @staticmethod
+    def resolve_resolution(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'resolution')
 
-    def resolve_reporter_id(self, info):
-        """Hide reporter_id for restricted access"""
-        if TicketGQLType._should_restrict_field('reporter_id', self, info):
-            return None
-        return self.reporter_id
+    @staticmethod
+    def resolve_reporter_id(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'reporter_id', restricted_value=None)
 
-    def resolve_channel(self, info):
-        """Return [Restricted] for restricted access"""
-        if TicketGQLType._should_restrict_field('channel', self, info):
-            return "[Restricted]"
-        return self.channel
-    
-    def resolve_attending_staff(self, info):
-        """Hide attending_staff for restricted access"""
-        if TicketGQLType._should_restrict_field('attending_staff', self, info):
-            return None
-        return self.attending_staff
-    
-    def resolve_json_ext(self, info):
-        """Hide json_ext for restricted access"""
-        if TicketGQLType._should_restrict_field('json_ext', self, info):
-            return None
-        return self.json_ext
-    
-    def resolve_category(self, info):
-        """Return category value based on visible_fields"""
-        if TicketGQLType._should_restrict_field('category', self, info):
-            return "[Restricted]" if self.category else None
-        return self.category
-    
-    def resolve_flags(self, info):
-        """Return flags value based on visible_fields"""
-        if TicketGQLType._should_restrict_field('flags', self, info):
-            return "[Restricted]" if self.flags else None
-        return self.flags
-    
-    def resolve_title(self, info):
-        """Return title value based on visible_fields"""
-        if TicketGQLType._should_restrict_field('title', self, info):
-            return "[Restricted]" if self.title else None
-        return self.title
-    
-    def resolve_status(self, info):
-        """Status is usually visible for restricted users"""
-        if TicketGQLType._should_restrict_field('status', self, info):
-            return None
-        return self.status
-    
-    def resolve_priority(self, info):
-        """Priority is usually visible for restricted users"""
-        if TicketGQLType._should_restrict_field('priority', self, info):
-            return None
-        return self.priority
-    
-    def resolve_date_created(self, info):
-        """Date created is usually visible for restricted users"""
-        if TicketGQLType._should_restrict_field('date_created', self, info):
-            return None
-        return self.date_created
-    
-    def resolve_date_of_incident(self, info):
-        """Date of incident might be restricted"""
-        if TicketGQLType._should_restrict_field('date_of_incident', self, info):
-            return None
-        return self.date_of_incident
-    
-    def resolve_due_date(self, info):
-        """Due date might be restricted"""
-        if TicketGQLType._should_restrict_field('due_date', self, info):
-            return None
-        return self.due_date
+    @staticmethod
+    def resolve_channel(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'channel')
+
+    @staticmethod
+    def resolve_attending_staff(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'attending_staff', restricted_value=None)
+
+    @staticmethod
+    def resolve_json_ext(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'json_ext', restricted_value=None)
+
+    @staticmethod
+    def resolve_category(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'category', preserve_none=True)
+
+    @staticmethod
+    def resolve_flags(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'flags', preserve_none=True)
+
+    @staticmethod
+    def resolve_title(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'title', preserve_none=True)
+
+    @staticmethod
+    def resolve_status(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'status', restricted_value=None)
+
+    @staticmethod
+    def resolve_priority(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'priority', restricted_value=None)
+
+    @staticmethod
+    def resolve_date_created(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'date_created', restricted_value=None)
+
+    @staticmethod
+    def resolve_date_of_incident(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'date_of_incident', restricted_value=None)
+
+    @staticmethod
+    def resolve_due_date(root, info):
+        return TicketGQLType._restricted_resolve(root, info, 'due_date', restricted_value=None)
     
 
     class Meta:
@@ -462,23 +449,13 @@ class GrievanceTypeConfigurationGQLType(ObjectType):
         return flags
     
     def resolve_grievance_category_staff_roles(self, info):
-        category_staff_role_list = []
-        for category_key, role_ids in TicketConfig.default_attending_staff_role_ids.items():
-            category_staff_role = AttendingStaffRoleGQLType(
-                category=category_key,
-                role_ids=role_ids
-            )
-            category_staff_role_list.append(category_staff_role)
-
-        return category_staff_role_list
+        return [
+            AttendingStaffRoleGQLType(category=category_key, role_ids=role_ids)
+            for category_key, role_ids in TicketConfig.default_attending_staff_role_ids.items()
+        ]
 
     def resolve_grievance_default_resolutions_by_category(self, info):
-        category_resolution_time_list = []
-        for category_key, resolution_time in TicketConfig.default_resolution.items():
-            category_resolution_time = ResolutionTimesByCategoryGQLType(
-                category=category_key,
-                resolution_time=resolution_time
-            )
-            category_resolution_time_list.append(category_resolution_time)
-
-        return category_resolution_time_list
+        return [
+            ResolutionTimesByCategoryGQLType(category=category_key, resolution_time=resolution_time)
+            for category_key, resolution_time in TicketConfig.default_resolution.items()
+        ]

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.rights import GrievanceRightsManager
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +100,8 @@ class Command(BaseCommand):
             perms = cat_info.get('permissions', [])
             if isinstance(perms, dict):
                 perms = list(perms.keys())
-            safe_name = cat_name.lower().replace(' ', '_').replace('|', '_')
             for perm_type in perms:
-                codename = f"{perm_type}_{safe_name}_grievance"
+                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
                 configured_perms.add(codename)
         
         # Collect configured flag permissions
@@ -109,9 +109,8 @@ class Command(BaseCommand):
             perms = flag_info.get('permissions', [])
             if isinstance(perms, dict):
                 perms = list(perms.keys())
-            safe_name = flag_name.lower().replace(' ', '_')
             for perm_type in perms:
-                codename = f"{perm_type}_flag_{safe_name}_grievance"
+                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
                 configured_perms.add(codename)
         
         # Get content type for Ticket model
@@ -215,10 +214,8 @@ class Command(BaseCommand):
             if isinstance(perms, dict):
                 perms = list(perms.keys())
             
-            safe_name = cat_name.lower().replace(' ', '_').replace('|', '_')
             for perm_type in perms:
-                codename = f"grievance_{safe_name}_{perm_type}"
-                name = f"Can {perm_type.replace('_', ' ')} {cat_name} tickets"
+                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
                 
                 if Permission.objects.filter(codename=codename, content_type=ct).exists():
                     existing.append(codename)
@@ -231,10 +228,8 @@ class Command(BaseCommand):
             if isinstance(perms, dict):
                 perms = list(perms.keys())
             
-            safe_name = flag_name.lower().replace(' ', '_')
             for perm_type in perms:
-                codename = f"grievance_flag_{safe_name}_{perm_type}"
-                name = f"Can {perm_type.replace('_', ' ')} {flag_name} flagged tickets"
+                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
                 
                 if Permission.objects.filter(codename=codename, content_type=ct).exists():
                     existing.append(codename)

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -1,0 +1,266 @@
+"""
+Management command to view and manage grievance permissions.
+"""
+import json
+import logging
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from grievance_social_protection.models import Ticket
+from grievance_social_protection.apps import TicketConfig
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = 'Manage grievance permissions in Django auth_permission table'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'action',
+            type=str,
+            choices=['list', 'cleanup', 'export', 'sync'],
+            help='Action to perform'
+        )
+        parser.add_argument(
+            '--format',
+            type=str,
+            default='table',
+            choices=['table', 'json', 'csv'],
+            help='Output format for list/export actions'
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be done without making changes'
+        )
+
+    def handle(self, *args, **options):
+        action = options['action']
+        
+        if action == 'list':
+            self.list_permissions(options['format'])
+        elif action == 'cleanup':
+            self.cleanup_permissions(options['dry_run'])
+        elif action == 'export':
+            self.export_permissions(options['format'])
+        elif action == 'sync':
+            self.sync_permissions(options['dry_run'])
+
+    def list_permissions(self, format_type):
+        # Get content type for Ticket model
+        try:
+            ct = ContentType.objects.get_for_model(Ticket)
+        except Exception as e:
+            logger.warning(f"Could not get ContentType for Ticket model: {e}")
+            return
+    
+        """List all grievance permissions"""
+        perms = Permission.objects.filter(
+            content_type=ct,
+            codename__endswith='_grievance',
+            id__range=(127100, 127999)
+        ).order_by('id')
+        
+        if format_type == 'table':
+            self.stdout.write("\nGrievance Permissions:")
+            self.stdout.write("-" * 80)
+            self.stdout.write(f"{'ID':<8} {'Codename':<50} {'Name':<30}")
+            self.stdout.write("-" * 80)
+            
+            for perm in perms:
+                self.stdout.write(f"{perm.id:<8} {perm.codename:<50} {perm.name[:30]:<30}")
+            
+            self.stdout.write("-" * 80)
+            self.stdout.write(f"Total: {perms.count()} permissions\n")
+            
+        elif format_type == 'json':
+            data = [
+                {
+                    'id': perm.id,
+                    'codename': perm.codename,
+                    'name': perm.name
+                }
+                for perm in perms
+            ]
+            self.stdout.write(json.dumps(data, indent=2))
+            
+        elif format_type == 'csv':
+            self.stdout.write("ID,Codename,Name")
+            for perm in perms:
+                self.stdout.write(f'{perm.id},"{perm.codename}","{perm.name}"')
+
+    def cleanup_permissions(self, dry_run):
+        """Remove orphaned permissions not in current configuration"""
+        # Get current configuration
+        configured_perms = set()
+        
+        # Collect configured category permissions
+        for cat_name, cat_info in TicketConfig.processed_categories.items():
+            perms = cat_info.get('permissions', [])
+            if isinstance(perms, dict):
+                perms = list(perms.keys())
+            safe_name = cat_name.lower().replace(' ', '_').replace('|', '_')
+            for perm_type in perms:
+                codename = f"{perm_type}_{safe_name}_grievance"
+                configured_perms.add(codename)
+        
+        # Collect configured flag permissions
+        for flag_name, flag_info in TicketConfig.processed_flags.items():
+            perms = flag_info.get('permissions', [])
+            if isinstance(perms, dict):
+                perms = list(perms.keys())
+            safe_name = flag_name.lower().replace(' ', '_')
+            for perm_type in perms:
+                codename = f"{perm_type}_flag_{safe_name}_grievance"
+                configured_perms.add(codename)
+        
+        # Get content type for Ticket model
+        try:
+            ct = ContentType.objects.get_for_model(Ticket)
+        except Exception as e:
+            logger.warning(f"Could not get ContentType for Ticket model: {e}")
+            return
+    
+        # Find orphaned permissions
+        all_perms = Permission.objects.filter(
+            content_type=ct,
+            codename__endswith='_grievance',
+            id__range=(127100, 127999)
+        )
+        
+        orphaned = []
+        for perm in all_perms:
+            if perm.codename not in configured_perms:
+                orphaned.append(perm)
+        
+        if not orphaned:
+            self.stdout.write(self.style.SUCCESS("No orphaned permissions found."))
+            return
+        
+        self.stdout.write(f"\nFound {len(orphaned)} orphaned permission(s):")
+        for perm in orphaned:
+            self.stdout.write(f"  - {perm.id}: {perm.codename}")
+        
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
+        else:
+            confirm = input("\nDelete these permissions? (yes/no): ")
+            if confirm.lower() == 'yes':
+                count = len(orphaned)
+                for perm in orphaned:
+                    perm.delete()
+                self.stdout.write(self.style.SUCCESS(f"Deleted {count} permission(s)."))
+            else:
+                self.stdout.write("Cleanup cancelled.")
+
+    def export_permissions(self, format_type):
+        """Export permission mapping for backup"""
+        data = {
+            'base_permissions': {},
+            'category_permissions': {},
+            'flag_permissions': {}
+        }
+        
+        # Export base permissions
+        base_perms = Permission.objects.filter(
+            id__range=(127000, 127099)
+        )
+        for perm in base_perms:
+            data['base_permissions'][perm.codename] = perm.id
+        
+        # Export category permissions
+        for cat_name, cat_info in TicketConfig.processed_categories.items():
+            if cat_info.get('generated_rights'):
+                data['category_permissions'][cat_name] = cat_info['generated_rights']
+        
+        # Export flag permissions
+        for flag_name, flag_info in TicketConfig.processed_flags.items():
+            if flag_info.get('generated_rights'):
+                data['flag_permissions'][flag_name] = flag_info['generated_rights']
+        
+        if format_type == 'json':
+            self.stdout.write(json.dumps(data, indent=2))
+        else:
+            self.stdout.write("\nPermission Export:")
+            self.stdout.write("=" * 60)
+            self.stdout.write("\nBase Permissions:")
+            for code, id in data['base_permissions'].items():
+                self.stdout.write(f"  {code}: {id}")
+            
+            self.stdout.write("\nCategory Permissions:")
+            for cat, perms in data['category_permissions'].items():
+                self.stdout.write(f"  {cat}:")
+                for ptype, pid in perms.items():
+                    self.stdout.write(f"    {ptype}: {pid}")
+            
+            self.stdout.write("\nFlag Permissions:")
+            for flag, perms in data['flag_permissions'].items():
+                self.stdout.write(f"  {flag}:")
+                for ptype, pid in perms.items():
+                    self.stdout.write(f"    {ptype}: {pid}")
+
+    def sync_permissions(self, dry_run):
+        """Sync permissions with current configuration"""
+        try:
+            ct = ContentType.objects.get_for_model(Ticket)
+        except Exception as e:
+            raise CommandError(f"Could not get ContentType: {e}")
+        
+        created = []
+        existing = []
+        
+        # Check category permissions
+        for cat_name, cat_info in TicketConfig.processed_categories.items():
+            perms = cat_info.get('permissions', [])
+            if isinstance(perms, dict):
+                perms = list(perms.keys())
+            
+            safe_name = cat_name.lower().replace(' ', '_').replace('|', '_')
+            for perm_type in perms:
+                codename = f"grievance_{safe_name}_{perm_type}"
+                name = f"Can {perm_type.replace('_', ' ')} {cat_name} tickets"
+                
+                if Permission.objects.filter(codename=codename, content_type=ct).exists():
+                    existing.append(codename)
+                else:
+                    created.append((codename, name))
+        
+        # Check flag permissions
+        for flag_name, flag_info in TicketConfig.processed_flags.items():
+            perms = flag_info.get('permissions', [])
+            if isinstance(perms, dict):
+                perms = list(perms.keys())
+            
+            safe_name = flag_name.lower().replace(' ', '_')
+            for perm_type in perms:
+                codename = f"grievance_flag_{safe_name}_{perm_type}"
+                name = f"Can {perm_type.replace('_', ' ')} {flag_name} flagged tickets"
+                
+                if Permission.objects.filter(codename=codename, content_type=ct).exists():
+                    existing.append(codename)
+                else:
+                    created.append((codename, name))
+        
+        self.stdout.write(f"\nPermission Sync Summary:")
+        self.stdout.write(f"  Existing: {len(existing)} permissions")
+        self.stdout.write(f"  To create: {len(created)} permissions")
+        
+        if created:
+            self.stdout.write("\nPermissions to create:")
+            for codename, name in created:
+                self.stdout.write(f"  - {codename}: {name}")
+        
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
+        else:
+            if created:
+                confirm = input("\nCreate these permissions? (yes/no): ")
+                if confirm.lower() == 'yes':
+                    # This will trigger the auto-generation in apps.py
+                    self.stdout.write("\nTriggering permission generation...")
+                    TicketConfig._TicketConfig__generate_automatic_rights()
+                    self.stdout.write(self.style.SUCCESS("Permissions synchronized."))
+                else:
+                    self.stdout.write("Sync cancelled.")
+            else:
+                self.stdout.write(self.style.SUCCESS("All permissions are up to date."))

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -34,6 +34,12 @@ class Command(BaseCommand):
             action='store_true',
             help='Show what would be done without making changes'
         )
+        parser.add_argument(
+            '--yes', '-y',
+            action='store_true',
+            dest='yes',
+            help='Skip confirmation prompts (for non-interactive environments like CI/CD)'
+        )
 
     def handle(self, *args, **options):
         action = options['action']
@@ -41,11 +47,11 @@ class Command(BaseCommand):
         if action == 'list':
             self.list_permissions(options['format'])
         elif action == 'cleanup':
-            self.cleanup_permissions(options['dry_run'])
+            self.cleanup_permissions(options['dry_run'], options['yes'])
         elif action == 'export':
             self.export_permissions(options['format'])
         elif action == 'sync':
-            self.sync_permissions(options['dry_run'])
+            self.sync_permissions(options['dry_run'], options['yes'])
 
     def list_permissions(self, format_type):
         # Get content type for Ticket model
@@ -90,7 +96,7 @@ class Command(BaseCommand):
             for perm in perms:
                 self.stdout.write(f'{perm.id},"{perm.codename}","{perm.name}"')
 
-    def cleanup_permissions(self, dry_run):
+    def cleanup_permissions(self, dry_run, skip_confirmation=False):
         """Remove orphaned permissions not in current configuration"""
         # Get current configuration
         configured_perms = set()
@@ -143,8 +149,13 @@ class Command(BaseCommand):
         if dry_run:
             self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
         else:
-            confirm = input("\nDelete these permissions? (yes/no): ")
-            if confirm.lower() == 'yes':
+            if skip_confirmation:
+                confirmed = True
+            else:
+                confirm = input("\nDelete these permissions? (yes/no): ")
+                confirmed = confirm.lower() == 'yes'
+
+            if confirmed:
                 count = len(orphaned)
                 for perm in orphaned:
                     perm.delete()
@@ -198,7 +209,7 @@ class Command(BaseCommand):
                 for ptype, pid in perms.items():
                     self.stdout.write(f"    {ptype}: {pid}")
 
-    def sync_permissions(self, dry_run):
+    def sync_permissions(self, dry_run, skip_confirmation=False):
         """Sync permissions with current configuration"""
         try:
             ct = ContentType.objects.get_for_model(Ticket)
@@ -249,11 +260,16 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
         else:
             if created:
-                confirm = input("\nCreate these permissions? (yes/no): ")
-                if confirm.lower() == 'yes':
-                    # This will trigger the auto-generation in apps.py
+                if skip_confirmation:
+                    confirmed = True
+                else:
+                    confirm = input("\nCreate these permissions? (yes/no): ")
+                    confirmed = confirm.lower() == 'yes'
+
+                if confirmed:
+                    # This will trigger the auto-generation
                     self.stdout.write("\nTriggering permission generation...")
-                    TicketConfig._TicketConfig__generate_automatic_rights()
+                    GrievanceRightsManager.generate_automatic_rights(TicketConfig)
                     self.stdout.write(self.style.SUCCESS("Permissions synchronized."))
                 else:
                     self.stdout.write("Sync cancelled.")

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -81,20 +81,20 @@ class Command(BaseCommand):
 
         for cat_name, cat_info in TicketConfig.processed_categories.items():
             for perm_type in cat_info.get('permissions', []):
-                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
+                codename, permission_name, _ = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
                 if Permission.objects.filter(codename=codename, content_type=ct).exists():
                     existing.append(codename)
                 else:
-                    missing.append((codename, name))
+                    missing.append((codename, permission_name))
 
         for flag_name, flag_info in TicketConfig.processed_flags.items():
             for perm_type in flag_info.get('permissions', []):
-                codename, _, name = GrievanceRightsManager._generate_permission_fields(
+                codename, permission_name, _ = GrievanceRightsManager._generate_permission_fields(
                     perm_type, flag_name, is_flag=True)
                 if Permission.objects.filter(codename=codename, content_type=ct).exists():
                     existing.append(codename)
                 else:
-                    missing.append((codename, name))
+                    missing.append((codename, permission_name))
 
         return existing, missing
 

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -53,15 +53,56 @@ class Command(BaseCommand):
         elif action == 'sync':
             self.sync_permissions(options['dry_run'], options['yes'])
 
+    def _collect_configured_codenames(self):
+        """Collect all permission codenames from the current configuration."""
+        codenames = set()
+
+        for cat_name, cat_info in TicketConfig.processed_categories.items():
+            for perm_type in cat_info.get('permissions', []):
+                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
+                codenames.add(codename)
+
+        for flag_name, flag_info in TicketConfig.processed_flags.items():
+            for perm_type in flag_info.get('permissions', []):
+                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
+                codenames.add(codename)
+
+        return codenames
+
+    def _collect_configured_permissions(self, ct):
+        """Collect configured permissions, split into existing and missing.
+
+        Returns a tuple of (existing_codenames, missing_permissions) where
+        missing_permissions is a list of (codename, name) tuples.
+        """
+        existing = []
+        missing = []
+
+        for cat_name, cat_info in TicketConfig.processed_categories.items():
+            for perm_type in cat_info.get('permissions', []):
+                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
+                if Permission.objects.filter(codename=codename, content_type=ct).exists():
+                    existing.append(codename)
+                else:
+                    missing.append((codename, name))
+
+        for flag_name, flag_info in TicketConfig.processed_flags.items():
+            for perm_type in flag_info.get('permissions', []):
+                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
+                if Permission.objects.filter(codename=codename, content_type=ct).exists():
+                    existing.append(codename)
+                else:
+                    missing.append((codename, name))
+
+        return existing, missing
+
     def list_permissions(self, format_type):
-        # Get content type for Ticket model
+        """List all grievance permissions."""
         try:
             ct = ContentType.objects.get_for_model(Ticket)
         except Exception as e:
             logger.warning(f"Could not get ContentType for Ticket model: {e}")
             return
-    
-        """List all grievance permissions"""
         perms = Permission.objects.filter(
             content_type=ct,
             codename__endswith='_grievance',
@@ -97,27 +138,8 @@ class Command(BaseCommand):
                 self.stdout.write(f'{perm.id},"{perm.codename}","{perm.name}"')
 
     def cleanup_permissions(self, dry_run, skip_confirmation=False):
-        """Remove orphaned permissions not in current configuration"""
-        # Get current configuration
-        configured_perms = set()
-        
-        # Collect configured category permissions
-        for cat_name, cat_info in TicketConfig.processed_categories.items():
-            perms = cat_info.get('permissions', [])
-            if isinstance(perms, dict):
-                perms = list(perms.keys())
-            for perm_type in perms:
-                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
-                configured_perms.add(codename)
-        
-        # Collect configured flag permissions
-        for flag_name, flag_info in TicketConfig.processed_flags.items():
-            perms = flag_info.get('permissions', [])
-            if isinstance(perms, dict):
-                perms = list(perms.keys())
-            for perm_type in perms:
-                codename, _, _ = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
-                configured_perms.add(codename)
+        """Remove orphaned permissions not in current configuration."""
+        configured_perms = self._collect_configured_codenames()
         
         # Get content type for Ticket model
         try:
@@ -210,42 +232,13 @@ class Command(BaseCommand):
                     self.stdout.write(f"    {ptype}: {pid}")
 
     def sync_permissions(self, dry_run, skip_confirmation=False):
-        """Sync permissions with current configuration"""
+        """Sync permissions with current configuration."""
         try:
             ct = ContentType.objects.get_for_model(Ticket)
         except Exception as e:
             raise CommandError(f"Could not get ContentType: {e}")
-        
-        created = []
-        existing = []
-        
-        # Check category permissions
-        for cat_name, cat_info in TicketConfig.processed_categories.items():
-            perms = cat_info.get('permissions', [])
-            if isinstance(perms, dict):
-                perms = list(perms.keys())
-            
-            for perm_type in perms:
-                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, cat_name)
-                
-                if Permission.objects.filter(codename=codename, content_type=ct).exists():
-                    existing.append(codename)
-                else:
-                    created.append((codename, name))
-        
-        # Check flag permissions
-        for flag_name, flag_info in TicketConfig.processed_flags.items():
-            perms = flag_info.get('permissions', [])
-            if isinstance(perms, dict):
-                perms = list(perms.keys())
-            
-            for perm_type in perms:
-                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
-                
-                if Permission.objects.filter(codename=codename, content_type=ct).exists():
-                    existing.append(codename)
-                else:
-                    created.append((codename, name))
+
+        existing, created = self._collect_configured_permissions(ct)
         
         self.stdout.write(f"\nPermission Sync Summary:")
         self.stdout.write(f"  Existing: {len(existing)} permissions")

--- a/grievance_social_protection/management/commands/manage_grievance_permissions.py
+++ b/grievance_social_protection/management/commands/manage_grievance_permissions.py
@@ -12,6 +12,7 @@ from grievance_social_protection.rights import GrievanceRightsManager
 
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
     help = 'Manage grievance permissions in Django auth_permission table'
 
@@ -43,7 +44,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         action = options['action']
-        
+
         if action == 'list':
             self.list_permissions(options['format'])
         elif action == 'cleanup':
@@ -88,7 +89,8 @@ class Command(BaseCommand):
 
         for flag_name, flag_info in TicketConfig.processed_flags.items():
             for perm_type in flag_info.get('permissions', []):
-                codename, _, name = GrievanceRightsManager._generate_permission_fields(perm_type, flag_name, is_flag=True)
+                codename, _, name = GrievanceRightsManager._generate_permission_fields(
+                    perm_type, flag_name, is_flag=True)
                 if Permission.objects.filter(codename=codename, content_type=ct).exists():
                     existing.append(codename)
                 else:
@@ -108,19 +110,19 @@ class Command(BaseCommand):
             codename__endswith='_grievance',
             id__range=(127100, 127999)
         ).order_by('id')
-        
+
         if format_type == 'table':
             self.stdout.write("\nGrievance Permissions:")
             self.stdout.write("-" * 80)
             self.stdout.write(f"{'ID':<8} {'Codename':<50} {'Name':<30}")
             self.stdout.write("-" * 80)
-            
+
             for perm in perms:
                 self.stdout.write(f"{perm.id:<8} {perm.codename:<50} {perm.name[:30]:<30}")
-            
+
             self.stdout.write("-" * 80)
             self.stdout.write(f"Total: {perms.count()} permissions\n")
-            
+
         elif format_type == 'json':
             data = [
                 {
@@ -131,7 +133,7 @@ class Command(BaseCommand):
                 for perm in perms
             ]
             self.stdout.write(json.dumps(data, indent=2))
-            
+
         elif format_type == 'csv':
             self.stdout.write("ID,Codename,Name")
             for perm in perms:
@@ -140,34 +142,34 @@ class Command(BaseCommand):
     def cleanup_permissions(self, dry_run, skip_confirmation=False):
         """Remove orphaned permissions not in current configuration."""
         configured_perms = self._collect_configured_codenames()
-        
+
         # Get content type for Ticket model
         try:
             ct = ContentType.objects.get_for_model(Ticket)
         except Exception as e:
             logger.warning(f"Could not get ContentType for Ticket model: {e}")
             return
-    
+
         # Find orphaned permissions
         all_perms = Permission.objects.filter(
             content_type=ct,
             codename__endswith='_grievance',
             id__range=(127100, 127999)
         )
-        
+
         orphaned = []
         for perm in all_perms:
             if perm.codename not in configured_perms:
                 orphaned.append(perm)
-        
+
         if not orphaned:
             self.stdout.write(self.style.SUCCESS("No orphaned permissions found."))
             return
-        
+
         self.stdout.write(f"\nFound {len(orphaned)} orphaned permission(s):")
         for perm in orphaned:
             self.stdout.write(f"  - {perm.id}: {perm.codename}")
-        
+
         if dry_run:
             self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
         else:
@@ -192,24 +194,24 @@ class Command(BaseCommand):
             'category_permissions': {},
             'flag_permissions': {}
         }
-        
+
         # Export base permissions
         base_perms = Permission.objects.filter(
             id__range=(127000, 127099)
         )
         for perm in base_perms:
             data['base_permissions'][perm.codename] = perm.id
-        
+
         # Export category permissions
         for cat_name, cat_info in TicketConfig.processed_categories.items():
             if cat_info.get('generated_rights'):
                 data['category_permissions'][cat_name] = cat_info['generated_rights']
-        
+
         # Export flag permissions
         for flag_name, flag_info in TicketConfig.processed_flags.items():
             if flag_info.get('generated_rights'):
                 data['flag_permissions'][flag_name] = flag_info['generated_rights']
-        
+
         if format_type == 'json':
             self.stdout.write(json.dumps(data, indent=2))
         else:
@@ -218,13 +220,13 @@ class Command(BaseCommand):
             self.stdout.write("\nBase Permissions:")
             for code, id in data['base_permissions'].items():
                 self.stdout.write(f"  {code}: {id}")
-            
+
             self.stdout.write("\nCategory Permissions:")
             for cat, perms in data['category_permissions'].items():
                 self.stdout.write(f"  {cat}:")
                 for ptype, pid in perms.items():
                     self.stdout.write(f"    {ptype}: {pid}")
-            
+
             self.stdout.write("\nFlag Permissions:")
             for flag, perms in data['flag_permissions'].items():
                 self.stdout.write(f"  {flag}:")
@@ -239,16 +241,16 @@ class Command(BaseCommand):
             raise CommandError(f"Could not get ContentType: {e}")
 
         existing, created = self._collect_configured_permissions(ct)
-        
-        self.stdout.write(f"\nPermission Sync Summary:")
+
+        self.stdout.write("\nPermission Sync Summary:")
         self.stdout.write(f"  Existing: {len(existing)} permissions")
         self.stdout.write(f"  To create: {len(created)} permissions")
-        
+
         if created:
             self.stdout.write("\nPermissions to create:")
             for codename, name in created:
                 self.stdout.write(f"  - {codename}: {name}")
-        
+
         if dry_run:
             self.stdout.write(self.style.WARNING("\nDry run - no changes made."))
         else:

--- a/grievance_social_protection/models.py
+++ b/grievance_social_protection/models.py
@@ -9,6 +9,7 @@ import core
 from core import models as core_models
 from core.models import HistoryBusinessModel, User, HistoryModel
 from .access_control import GrievanceAccessControl
+from .apps import TicketConfig
 
 
 def check_if_user_or_individual(generic_field):
@@ -56,6 +57,12 @@ class Ticket(HistoryBusinessModel):
 
     def __str__(self):
         return f"{self.title}"
+    
+    def save(self, *args, **kwargs):
+        # Set default category if empty
+        if not self.category:
+            self.category = TicketConfig.default_grievance_type
+        super().save(*args, **kwargs)
 
 
     @classmethod

--- a/grievance_social_protection/models.py
+++ b/grievance_social_protection/models.py
@@ -5,7 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from graphql import ResolveInfo
 
-import core
 from core import models as core_models
 from core.models import HistoryBusinessModel, User, HistoryModel
 from .access_control import GrievanceAccessControl
@@ -69,7 +68,7 @@ class Ticket(HistoryBusinessModel):
     def filter_queryset(cls, queryset=None):
         if queryset is None:
             queryset = cls.objects.all()
-        queryset = queryset.filter(*core.filter_validity())
+        queryset = queryset.filter(is_deleted=False, date_valid_to__isnull=True)
         return queryset
 
     @classmethod

--- a/grievance_social_protection/models.py
+++ b/grievance_social_protection/models.py
@@ -69,12 +69,7 @@ class Ticket(HistoryBusinessModel):
     def filter_queryset(cls, queryset=None):
         if queryset is None:
             queryset = cls.objects.all()
-        # Filter by validity dates using the actual field names
-        from core.utils import TimeUtils
-        queryset = queryset.filter(
-            models.Q(date_valid_from__lte=TimeUtils.now()) | models.Q(date_valid_from__isnull=True),
-            models.Q(date_valid_to__gte=TimeUtils.now()) | models.Q(date_valid_to__isnull=True),
-        )
+        queryset = queryset.filter(*core.filter_validity())
         return queryset
 
     @classmethod

--- a/grievance_social_protection/models.py
+++ b/grievance_social_protection/models.py
@@ -8,6 +8,7 @@ from graphql import ResolveInfo
 import core
 from core import models as core_models
 from core.models import HistoryBusinessModel, User, HistoryModel
+from .access_control import GrievanceAccessControl
 
 
 def check_if_user_or_individual(generic_field):
@@ -61,7 +62,12 @@ class Ticket(HistoryBusinessModel):
     def filter_queryset(cls, queryset=None):
         if queryset is None:
             queryset = cls.objects.all()
-        queryset = queryset.filter(*core.filter_validity())
+        # Filter by validity dates using the actual field names
+        from core.utils import TimeUtils
+        queryset = queryset.filter(
+            models.Q(date_valid_from__lte=TimeUtils.now()) | models.Q(date_valid_from__isnull=True),
+            models.Q(date_valid_to__gte=TimeUtils.now()) | models.Q(date_valid_to__isnull=True),
+        )
         return queryset
 
     @classmethod
@@ -72,7 +78,8 @@ class Ticket(HistoryBusinessModel):
         if settings.ROW_SECURITY and user.is_anonymous:
             return queryset.filter(id=None)
         if settings.ROW_SECURITY:
-            pass
+            # Apply category and flag permission filtering
+            queryset = GrievanceAccessControl.filter_ticket_queryset(queryset, user)
         return queryset
 
 
@@ -108,6 +115,32 @@ class Comment(HistoryModel):
 
             if existing_resolved_comments.exists():
                 raise ValueError("Another comment for this ticket is already marked as resolved.")
+
+    @classmethod
+    def filter_queryset(cls, queryset=None):
+        if queryset is None:
+            queryset = cls.objects.all()
+        queryset = queryset.filter(is_deleted=False)
+        return queryset
+
+    @classmethod
+    def get_queryset(cls, queryset, user):
+        queryset = cls.filter_queryset(queryset)
+        # GraphQL calls with an info object while Rest calls with the user itself
+        if isinstance(user, ResolveInfo):
+            user = user.context.user
+        if settings.ROW_SECURITY and user.is_anonymous:
+            return queryset.filter(id=None)
+        if settings.ROW_SECURITY:
+            # Filter out comments for tickets the user cannot see
+            # Get the tickets queryset filtered by user permissions
+            allowed_tickets = Ticket.filter_queryset()
+            allowed_tickets = GrievanceAccessControl.filter_ticket_queryset(allowed_tickets, user)
+            allowed_ticket_ids = allowed_tickets.values_list('id', flat=True)
+            
+            # Only show comments for tickets the user can access
+            queryset = queryset.filter(ticket_id__in=allowed_ticket_ids)
+        return queryset
 
 
 # LEFT IF NEEDED IN THE FUTURE

--- a/grievance_social_protection/models.py
+++ b/grievance_social_protection/models.py
@@ -56,13 +56,12 @@ class Ticket(HistoryBusinessModel):
 
     def __str__(self):
         return f"{self.title}"
-    
+
     def save(self, *args, **kwargs):
         # Set default category if empty
         if not self.category:
             self.category = TicketConfig.default_grievance_type
         super().save(*args, **kwargs)
-
 
     @classmethod
     def filter_queryset(cls, queryset=None):
@@ -138,7 +137,7 @@ class Comment(HistoryModel):
             allowed_tickets = Ticket.filter_queryset()
             allowed_tickets = GrievanceAccessControl.filter_ticket_queryset(allowed_tickets, user)
             allowed_ticket_ids = allowed_tickets.values_list('id', flat=True)
-            
+
             # Only show comments for tickets the user can access
             queryset = queryset.filter(ticket_id__in=allowed_ticket_ids)
         return queryset

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -68,16 +68,22 @@ class GrievanceRightsManager:
                 perm_type, item_name, is_flag=is_flag
             )
 
-            # Check if permission already exists
+            # Check if permission already exists (in reserved range first, then globally)
             if codename in existing_by_codename:
                 perm = existing_by_codename[codename]
+            else:
+                # Also check outside reserved range to avoid codename uniqueness violations
+                perm = Permission.objects.filter(
+                    codename=codename, content_type=ct
+                ).first()
+
+            if perm:
                 item_info['generated_rights'][perm_type] = perm.id
                 logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
             else:
                 # Generate new ID following suffix pattern
                 new_id = cls._get_next_available_id(perm_type, used_ids)
 
-                # Create new permission
                 perm = Permission.objects.create(
                     id=new_id,
                     codename=codename,

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -6,7 +6,7 @@ import re
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from .models import Ticket
 
 logger = logging.getLogger(__name__)
@@ -100,42 +100,51 @@ class GrievanceRightsManager:
         # Get content type for Ticket model
         ct = ContentType.objects.get_for_model(Ticket)
 
-        with transaction.atomic():
-            # Lock all permissions in our reserved range to prevent race conditions
-            # during concurrent app startups. select_for_update() acquires row-level
-            # locks that block other transactions from reading these rows until we commit.
-            locked_perms = Permission.objects.select_for_update().filter(
-                id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
-            )
+        # Retry loop: select_for_update only locks existing rows, so concurrent
+        # startups with an empty reserved range can race on INSERT. On
+        # IntegrityError we retry with refreshed locks.
+        max_retries = 3
+        all_rights = {}
 
-            # Build used_ids from locked queryset to ensure consistency
-            used_ids = set(locked_perms.values_list('id', flat=True))
+        for attempt in range(1, max_retries + 1):
+            try:
+                with transaction.atomic():
+                    locked_perms = Permission.objects.select_for_update().filter(
+                        id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
+                    )
 
-            # Get all existing grievance permissions from the reserved range
-            existing_perms = locked_perms.filter(
-                content_type=ct,
-                codename__endswith='_grievance',
-            )
+                    used_ids = set(locked_perms.values_list('id', flat=True))
 
-            # Build map of existing permissions by codename
-            existing_by_codename = {perm.codename: perm for perm in existing_perms}
+                    existing_perms = locked_perms.filter(
+                        content_type=ct,
+                        codename__endswith='_grievance',
+                    )
 
-            all_rights = {}  # Collect all rights
+                    existing_by_codename = {perm.codename: perm for perm in existing_perms}
 
-            # Process categories
-            processed_categories = getattr(app_config, 'processed_categories', {})
-            for category_name, category_info in processed_categories.items():
-                cls._process_permissions(
-                    category_name, category_info, False,
-                    existing_by_codename, used_ids, ct, all_rights
-                )
+                    all_rights = {}
 
-            # Process flags
-            processed_flags = getattr(app_config, 'processed_flags', {})
-            for flag_name, flag_info in processed_flags.items():
-                cls._process_permissions(
-                    flag_name, flag_info, True,
-                    existing_by_codename, used_ids, ct, all_rights
+                    processed_categories = getattr(app_config, 'processed_categories', {})
+                    for category_name, category_info in processed_categories.items():
+                        cls._process_permissions(
+                            category_name, category_info, False,
+                            existing_by_codename, used_ids, ct, all_rights
+                        )
+
+                    processed_flags = getattr(app_config, 'processed_flags', {})
+                    for flag_name, flag_info in processed_flags.items():
+                        cls._process_permissions(
+                            flag_name, flag_info, True,
+                            existing_by_codename, used_ids, ct, all_rights
+                        )
+                # Transaction committed successfully
+                break
+            except IntegrityError:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "IntegrityError generating grievance rights (attempt %s/%s), retrying...",
+                    attempt, max_retries
                 )
 
         # Store generated rights for documentation (outside transaction)

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -7,6 +7,7 @@ import re
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction, IntegrityError
+from .apps import DEFAULT_CFG
 from .models import Ticket
 
 logger = logging.getLogger(__name__)
@@ -167,10 +168,12 @@ class GrievanceRightsManager:
                     grouped_rights[right_name] = []
                 grouped_rights[right_name].append(right_id)
 
-            # Set as class attribute only - do not mutate the module-level DEFAULT_CFG
-            # to avoid shared state issues across concurrent processes
+            # Set as class attribute AND inject into DEFAULT_CFG so that
+            # core.utils.collect_all_gql_permissions() discovers them for
+            # the role configuration rights dropdown.
             for right_name, right_ids in grouped_rights.items():
                 setattr(app_config, right_name, right_ids)
+                DEFAULT_CFG[right_name] = [str(rid) for rid in right_ids]
 
     @classmethod
     def _get_next_available_id(cls, perm_type, used_ids):

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -1,0 +1,207 @@
+"""
+Rights Manager for grievance categories and flags.
+"""
+import logging
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from .models import Ticket
+
+logger = logging.getLogger(__name__)
+
+
+class GrievanceRightsManager:
+    """Manages automatic rights generation for grievance categories and flags"""
+
+    # Reserve 127100-127999 for dynamic grievance permissions
+    GRIEVANCE_RIGHT_BASE = 127100
+    GRIEVANCE_RIGHT_MAX = 127999
+
+    @classmethod
+    def generate_automatic_rights(cls, app_config):
+        """
+        Generate automatic rights using Django's auth_permission table.
+        Permissions are stored persistently to maintain stable IDs across config changes.
+        """
+        
+        # Get content type for Ticket model
+        try:
+            ct = ContentType.objects.get_for_model(Ticket)
+        except Exception as e:
+            logger.warning(f"Could not get ContentType for Ticket model: {e}")
+            return
+        
+        # Get all existing grievance permissions from the reserved range
+        existing_perms = Permission.objects.filter(
+            content_type=ct,
+            codename__endswith='_grievance',
+            id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
+        )
+        
+        # Build map of existing permissions by codename
+        existing_by_codename = {perm.codename: perm for perm in existing_perms}
+        
+        # Get used IDs in our range
+        used_ids = set(Permission.objects.filter(
+            id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
+        ).values_list('id', flat=True))
+        
+        all_rights = {}  # Collect all rights
+        
+        # Process categories
+        processed_categories = getattr(app_config, 'processed_categories', {})
+        
+        for category_name, category_info in processed_categories.items():
+            permissions = category_info.get('permissions', [])
+            if permissions:
+                # Convert back to list format if still dict
+                if isinstance(permissions, dict):
+                    permissions = list(permissions.keys())
+                
+                category_info['generated_rights'] = {}
+                safe_name = category_name.lower().replace(' ', '_').replace('|', '_')
+                
+                for perm_type in permissions:
+                    # Generate codename
+                    codename = f"{perm_type}_{safe_name}_grievance"
+                    
+                    # Check if permission already exists
+                    if codename in existing_by_codename:
+                        perm = existing_by_codename[codename]
+                        category_info['generated_rights'][perm_type] = perm.id
+                        logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
+                    else:
+                        # Generate new ID following suffix pattern
+                        try:
+                            new_id = cls._get_next_available_id(perm_type, used_ids)
+                            
+                            # Create new permission
+                            perm = Permission.objects.create(
+                                id=new_id,
+                                codename=codename,
+                                name=f"Can {perm_type.replace('_', ' ')} {category_name} tickets",
+                                content_type=ct
+                            )
+                            
+                            category_info['generated_rights'][perm_type] = perm.id
+                            used_ids.add(new_id)
+                            logger.info(f"Created new permission: {codename} (ID: {new_id})")
+                        except ValueError as e:
+                            logger.error(f"Failed to create permission {codename}: {e}")
+                            continue
+                    
+                    # Add to all_rights with OpenIMIS naming convention
+                    if perm_type == 'restricted_read':
+                        right_name = f"gql_query_restricted_{safe_name}_category_tickets_perms"
+                    elif perm_type == 'read':
+                        right_name = f"gql_query_{safe_name}_category_tickets_perms"
+                    elif perm_type == 'create':
+                        right_name = f"gql_mutation_create_{safe_name}_category_tickets_perms"
+                    elif perm_type == 'update':
+                        right_name = f"gql_mutation_update_{safe_name}_category_tickets_perms"
+                    elif perm_type == 'delete':
+                        right_name = f"gql_mutation_delete_{safe_name}_category_tickets_perms"
+                    else:
+                        continue
+                    
+                    all_rights[right_name] = category_info['generated_rights'][perm_type]
+        
+        # Process flags
+        processed_flags = getattr(app_config, 'processed_flags', {})
+        
+        for flag_name, flag_info in processed_flags.items():
+            permissions = flag_info.get('permissions', [])
+            if permissions:
+                # Convert back to list format if still dict
+                if isinstance(permissions, dict):
+                    permissions = list(permissions.keys())
+                
+                flag_info['generated_rights'] = {}
+                safe_name = flag_name.lower().replace(' ', '_')
+                
+                for perm_type in permissions:
+                    # Generate codename
+                    codename = f"{perm_type}_flag_{safe_name}_grievance"
+                    
+                    # Check if permission already exists
+                    if codename in existing_by_codename:
+                        perm = existing_by_codename[codename]
+                        flag_info['generated_rights'][perm_type] = perm.id
+                        logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
+                    else:
+                        # Generate new ID following suffix pattern
+                        try:
+                            new_id = cls._get_next_available_id(perm_type, used_ids)
+                            
+                            # Create new permission
+                            perm = Permission.objects.create(
+                                id=new_id,
+                                codename=codename,
+                                name=f"Can {perm_type.replace('_', ' ')} {flag_name} flagged tickets",
+                                content_type=ct
+                            )
+                            
+                            flag_info['generated_rights'][perm_type] = perm.id
+                            used_ids.add(new_id)
+                            logger.info(f"Created new permission: {codename} (ID: {new_id})")
+                        except ValueError as e:
+                            logger.error(f"Failed to create permission {codename}: {e}")
+                            continue
+                    
+                    # Add to all_rights with OpenIMIS naming convention
+                    if perm_type == 'restricted_read':
+                        right_name = f"gql_query_restricted_{safe_name}_flagged_tickets_perms"
+                    elif perm_type == 'read':
+                        right_name = f"gql_query_{safe_name}_flagged_tickets_perms"
+                    elif perm_type == 'create':
+                        right_name = f"gql_mutation_create_{safe_name}_flagged_tickets_perms"
+                    elif perm_type == 'update':
+                        right_name = f"gql_mutation_update_{safe_name}_flagged_tickets_perms"
+                    elif perm_type == 'delete':
+                        right_name = f"gql_mutation_delete_{safe_name}_flagged_tickets_perms"
+                    else:
+                        continue
+                    
+                    all_rights[right_name] = flag_info['generated_rights'][perm_type]
+        
+        # Store generated rights for documentation
+        app_config.generated_rights = all_rights
+        
+        # Log summary of permissions
+        if all_rights:
+            logger.info(f"Generated/verified {len(all_rights)} grievance permissions")
+            
+            # Group rights by permission name to match OpenIMIS convention
+            grouped_rights = {}
+            for right_name, right_id in all_rights.items():
+                if right_name not in grouped_rights:
+                    grouped_rights[right_name] = []
+                grouped_rights[right_name].append(right_id)
+            
+            # Update DEFAULT_CFG with generated permissions
+            from .apps import DEFAULT_CFG
+            for right_name, right_ids in grouped_rights.items():
+                DEFAULT_CFG[right_name] = right_ids
+                # Also set as class attribute
+                setattr(app_config, right_name, right_ids)
+
+    @classmethod
+    def _get_next_available_id(cls, perm_type, used_ids):
+        suffix_map = {
+            'read': 0,              # -> gql_query_*
+            'create': 1,            # -> gql_mutation_create_*
+            'update': 2,            # -> gql_mutation_update_*
+            'delete': 3,            # -> gql_mutation_delete_*
+            'restricted_read': 4,   # -> gql_query_restricted_*
+        }
+        
+        suffix = suffix_map.get(perm_type, 9)
+        
+        # Start from base and find next available with correct suffix
+        candidate = cls.GRIEVANCE_RIGHT_BASE + suffix
+        while candidate in used_ids and candidate <= cls.GRIEVANCE_RIGHT_MAX:
+            candidate += 10  # Maintain suffix while incrementing
+            
+        if candidate > cls.GRIEVANCE_RIGHT_MAX:
+            raise ValueError(f"No available ID for permission type {perm_type}")
+            
+        return candidate  

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -6,7 +6,7 @@ import re
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from .apps import DEFAULT_CFG
+from django.db import transaction
 from .models import Ticket
 
 logger = logging.getLogger(__name__)
@@ -60,9 +60,6 @@ class GrievanceRightsManager:
             all_rights: Dictionary to collect all rights
         """
         permissions = item_info.get('permissions', [])
-        if not permissions:
-            return
-            
         item_info['generated_rights'] = {}
         
         for perm_type in permissions:
@@ -78,23 +75,19 @@ class GrievanceRightsManager:
                 logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
             else:
                 # Generate new ID following suffix pattern
-                try:
-                    new_id = cls._get_next_available_id(perm_type, used_ids)
-                    
-                    # Create new permission
-                    perm = Permission.objects.create(
-                        id=new_id,
-                        codename=codename,
-                        name=permission_name,
-                        content_type=ct
-                    )
-                    
-                    item_info['generated_rights'][perm_type] = perm.id
-                    used_ids.add(new_id)
-                    logger.info(f"Created new permission: {codename} (ID: {new_id})")
-                except ValueError as e:
-                    logger.error(f"Failed to create permission {codename}: {e}")
-                    continue
+                new_id = cls._get_next_available_id(perm_type, used_ids)
+
+                # Create new permission
+                perm = Permission.objects.create(
+                    id=new_id,
+                    codename=codename,
+                    name=permission_name,
+                    content_type=ct
+                )
+
+                item_info['generated_rights'][perm_type] = perm.id
+                used_ids.add(new_id)
+                logger.info(f"Created new permission: {codename} (ID: {new_id})")
             
             all_rights[right_name] = item_info['generated_rights'][perm_type]
 
@@ -104,60 +97,64 @@ class GrievanceRightsManager:
         Generate automatic rights using Django's auth_permission table.
         Permissions are stored persistently to maintain stable IDs across config changes.
         """
-        
         # Get content type for Ticket model
         ct = ContentType.objects.get_for_model(Ticket)
-        
-        # Get all existing grievance permissions from the reserved range
-        existing_perms = Permission.objects.filter(
-            content_type=ct,
-            codename__endswith='_grievance',
-            id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
-        )
-        
-        # Build map of existing permissions by codename
-        existing_by_codename = {perm.codename: perm for perm in existing_perms}
-        
-        # Get used IDs in our range
-        used_ids = set(Permission.objects.filter(
-            id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
-        ).values_list('id', flat=True))
-        
-        all_rights = {}  # Collect all rights
-        
-        # Process categories
-        processed_categories = getattr(app_config, 'processed_categories', {})
-        for category_name, category_info in processed_categories.items():
-            cls._process_permissions(
-                category_name, category_info, False, 
-                existing_by_codename, used_ids, ct, all_rights
+
+        with transaction.atomic():
+            # Lock all permissions in our reserved range to prevent race conditions
+            # during concurrent app startups. select_for_update() acquires row-level
+            # locks that block other transactions from reading these rows until we commit.
+            locked_perms = Permission.objects.select_for_update().filter(
+                id__range=(cls.GRIEVANCE_RIGHT_BASE, cls.GRIEVANCE_RIGHT_MAX)
             )
-        
-        # Process flags
-        processed_flags = getattr(app_config, 'processed_flags', {})
-        for flag_name, flag_info in processed_flags.items():
-            cls._process_permissions(
-                flag_name, flag_info, True,
-                existing_by_codename, used_ids, ct, all_rights
+
+            # Build used_ids from locked queryset to ensure consistency
+            used_ids = set(locked_perms.values_list('id', flat=True))
+
+            # Get all existing grievance permissions from the reserved range
+            existing_perms = locked_perms.filter(
+                content_type=ct,
+                codename__endswith='_grievance',
             )
-        
-        # Store generated rights for documentation
+
+            # Build map of existing permissions by codename
+            existing_by_codename = {perm.codename: perm for perm in existing_perms}
+
+            all_rights = {}  # Collect all rights
+
+            # Process categories
+            processed_categories = getattr(app_config, 'processed_categories', {})
+            for category_name, category_info in processed_categories.items():
+                cls._process_permissions(
+                    category_name, category_info, False,
+                    existing_by_codename, used_ids, ct, all_rights
+                )
+
+            # Process flags
+            processed_flags = getattr(app_config, 'processed_flags', {})
+            for flag_name, flag_info in processed_flags.items():
+                cls._process_permissions(
+                    flag_name, flag_info, True,
+                    existing_by_codename, used_ids, ct, all_rights
+                )
+
+        # Store generated rights for documentation (outside transaction)
         app_config.generated_rights = all_rights
-        
+
         # Log summary of permissions
         if all_rights:
             logger.info(f"Generated/verified {len(all_rights)} grievance permissions")
-            
+
             # Group rights by permission name to match OpenIMIS convention
             grouped_rights = {}
             for right_name, right_id in all_rights.items():
                 if right_name not in grouped_rights:
                     grouped_rights[right_name] = []
                 grouped_rights[right_name].append(right_id)
-            
-            # Set as class attribute
+
+            # Set as class attribute only - do not mutate the module-level DEFAULT_CFG
+            # to avoid shared state issues across concurrent processes
             for right_name, right_ids in grouped_rights.items():
-                DEFAULT_CFG[right_name] = right_ids
                 setattr(app_config, right_name, right_ids)
 
     @classmethod

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -2,6 +2,8 @@
 Rights Manager for grievance categories and flags.
 """
 import logging
+import re
+
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from .models import Ticket
@@ -15,6 +17,85 @@ class GrievanceRightsManager:
     # Reserve 127100-127999 for dynamic grievance permissions
     GRIEVANCE_RIGHT_BASE = 127100
     GRIEVANCE_RIGHT_MAX = 127999
+    
+    # Permission fields limits
+    CODENAME_MAX_LENGTH = 100
+    PERMISSION_NAME_MAX_LENGTH = 255
+    
+    # Permission type mappings
+    PERM_TYPE_MAPPING = {
+        'restricted_read': 'gql_query_restricted',
+        'read': 'gql_query',
+        'create': 'gql_mutation_create',
+        'update': 'gql_mutation_update',
+        'delete': 'gql_mutation_delete'
+    }
+    
+    # Permission ID suffix mapping
+    PERM_TYPE_SUFFIX = {
+        'read': 0,
+        'create': 1,
+        'update': 2,
+        'delete': 3,
+        'restricted_read': 4,
+    }
+    
+    # Regular expressions
+    PARENTHESES_CONTENT_RE = re.compile(r'\s*\([^)]*\)')
+    NON_ALPHANUMERIC_RE = re.compile(r'[^a-z0-9_]')
+
+    @classmethod
+    def _process_permissions(cls, item_name, item_info, is_flag, existing_by_codename, used_ids, ct, all_rights):
+        """
+        Process permissions for a single category or flag.
+        
+        Args:
+            item_name: Name of the category or flag
+            item_info: Dictionary containing item configuration
+            is_flag: Whether this is a flag (True) or category (False)
+            existing_by_codename: Map of existing permissions by codename
+            used_ids: Set of used permission IDs
+            ct: ContentType for Ticket model
+            all_rights: Dictionary to collect all rights
+        """
+        permissions = item_info.get('permissions', [])
+        if not permissions:
+            return
+            
+        item_info['generated_rights'] = {}
+        
+        for perm_type in permissions:
+            # Generate codename with length limit
+            codename, permission_name, right_name = cls._generate_permission_fields(
+                perm_type, item_name, is_flag=is_flag
+            )
+            
+            # Check if permission already exists
+            if codename in existing_by_codename:
+                perm = existing_by_codename[codename]
+                item_info['generated_rights'][perm_type] = perm.id
+                logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
+            else:
+                # Generate new ID following suffix pattern
+                try:
+                    new_id = cls._get_next_available_id(perm_type, used_ids)
+                    
+                    # Create new permission
+                    perm = Permission.objects.create(
+                        id=new_id,
+                        codename=codename,
+                        name=permission_name,
+                        content_type=ct
+                    )
+                    
+                    item_info['generated_rights'][perm_type] = perm.id
+                    used_ids.add(new_id)
+                    logger.info(f"Created new permission: {codename} (ID: {new_id})")
+                except ValueError as e:
+                    logger.error(f"Failed to create permission {codename}: {e}")
+                    continue
+            
+            all_rights[right_name] = item_info['generated_rights'][perm_type]
 
     @classmethod
     def generate_automatic_rights(cls, app_config):
@@ -24,11 +105,7 @@ class GrievanceRightsManager:
         """
         
         # Get content type for Ticket model
-        try:
-            ct = ContentType.objects.get_for_model(Ticket)
-        except Exception as e:
-            logger.warning(f"Could not get ContentType for Ticket model: {e}")
-            return
+        ct = ContentType.objects.get_for_model(Ticket)
         
         # Get all existing grievance permissions from the reserved range
         existing_perms = Permission.objects.filter(
@@ -49,119 +126,19 @@ class GrievanceRightsManager:
         
         # Process categories
         processed_categories = getattr(app_config, 'processed_categories', {})
-        
         for category_name, category_info in processed_categories.items():
-            permissions = category_info.get('permissions', [])
-            if permissions:
-                # Convert back to list format if still dict
-                if isinstance(permissions, dict):
-                    permissions = list(permissions.keys())
-                
-                category_info['generated_rights'] = {}
-                safe_name = category_name.lower().replace(' ', '_').replace('|', '_')
-                
-                for perm_type in permissions:
-                    # Generate codename
-                    codename = f"{perm_type}_{safe_name}_grievance"
-                    
-                    # Check if permission already exists
-                    if codename in existing_by_codename:
-                        perm = existing_by_codename[codename]
-                        category_info['generated_rights'][perm_type] = perm.id
-                        logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
-                    else:
-                        # Generate new ID following suffix pattern
-                        try:
-                            new_id = cls._get_next_available_id(perm_type, used_ids)
-                            
-                            # Create new permission
-                            perm = Permission.objects.create(
-                                id=new_id,
-                                codename=codename,
-                                name=f"Can {perm_type.replace('_', ' ')} {category_name} tickets",
-                                content_type=ct
-                            )
-                            
-                            category_info['generated_rights'][perm_type] = perm.id
-                            used_ids.add(new_id)
-                            logger.info(f"Created new permission: {codename} (ID: {new_id})")
-                        except ValueError as e:
-                            logger.error(f"Failed to create permission {codename}: {e}")
-                            continue
-                    
-                    # Add to all_rights with OpenIMIS naming convention
-                    if perm_type == 'restricted_read':
-                        right_name = f"gql_query_restricted_{safe_name}_category_tickets_perms"
-                    elif perm_type == 'read':
-                        right_name = f"gql_query_{safe_name}_category_tickets_perms"
-                    elif perm_type == 'create':
-                        right_name = f"gql_mutation_create_{safe_name}_category_tickets_perms"
-                    elif perm_type == 'update':
-                        right_name = f"gql_mutation_update_{safe_name}_category_tickets_perms"
-                    elif perm_type == 'delete':
-                        right_name = f"gql_mutation_delete_{safe_name}_category_tickets_perms"
-                    else:
-                        continue
-                    
-                    all_rights[right_name] = category_info['generated_rights'][perm_type]
+            cls._process_permissions(
+                category_name, category_info, False, 
+                existing_by_codename, used_ids, ct, all_rights
+            )
         
         # Process flags
         processed_flags = getattr(app_config, 'processed_flags', {})
-        
         for flag_name, flag_info in processed_flags.items():
-            permissions = flag_info.get('permissions', [])
-            if permissions:
-                # Convert back to list format if still dict
-                if isinstance(permissions, dict):
-                    permissions = list(permissions.keys())
-                
-                flag_info['generated_rights'] = {}
-                safe_name = flag_name.lower().replace(' ', '_')
-                
-                for perm_type in permissions:
-                    # Generate codename
-                    codename = f"{perm_type}_flag_{safe_name}_grievance"
-                    
-                    # Check if permission already exists
-                    if codename in existing_by_codename:
-                        perm = existing_by_codename[codename]
-                        flag_info['generated_rights'][perm_type] = perm.id
-                        logger.info(f"Using existing permission: {codename} (ID: {perm.id})")
-                    else:
-                        # Generate new ID following suffix pattern
-                        try:
-                            new_id = cls._get_next_available_id(perm_type, used_ids)
-                            
-                            # Create new permission
-                            perm = Permission.objects.create(
-                                id=new_id,
-                                codename=codename,
-                                name=f"Can {perm_type.replace('_', ' ')} {flag_name} flagged tickets",
-                                content_type=ct
-                            )
-                            
-                            flag_info['generated_rights'][perm_type] = perm.id
-                            used_ids.add(new_id)
-                            logger.info(f"Created new permission: {codename} (ID: {new_id})")
-                        except ValueError as e:
-                            logger.error(f"Failed to create permission {codename}: {e}")
-                            continue
-                    
-                    # Add to all_rights with OpenIMIS naming convention
-                    if perm_type == 'restricted_read':
-                        right_name = f"gql_query_restricted_{safe_name}_flagged_tickets_perms"
-                    elif perm_type == 'read':
-                        right_name = f"gql_query_{safe_name}_flagged_tickets_perms"
-                    elif perm_type == 'create':
-                        right_name = f"gql_mutation_create_{safe_name}_flagged_tickets_perms"
-                    elif perm_type == 'update':
-                        right_name = f"gql_mutation_update_{safe_name}_flagged_tickets_perms"
-                    elif perm_type == 'delete':
-                        right_name = f"gql_mutation_delete_{safe_name}_flagged_tickets_perms"
-                    else:
-                        continue
-                    
-                    all_rights[right_name] = flag_info['generated_rights'][perm_type]
+            cls._process_permissions(
+                flag_name, flag_info, True,
+                existing_by_codename, used_ids, ct, all_rights
+            )
         
         # Store generated rights for documentation
         app_config.generated_rights = all_rights
@@ -177,24 +154,13 @@ class GrievanceRightsManager:
                     grouped_rights[right_name] = []
                 grouped_rights[right_name].append(right_id)
             
-            # Update DEFAULT_CFG with generated permissions
-            from .apps import DEFAULT_CFG
+            # Set as class attribute
             for right_name, right_ids in grouped_rights.items():
-                DEFAULT_CFG[right_name] = right_ids
-                # Also set as class attribute
                 setattr(app_config, right_name, right_ids)
 
     @classmethod
     def _get_next_available_id(cls, perm_type, used_ids):
-        suffix_map = {
-            'read': 0,              # -> gql_query_*
-            'create': 1,            # -> gql_mutation_create_*
-            'update': 2,            # -> gql_mutation_update_*
-            'delete': 3,            # -> gql_mutation_delete_*
-            'restricted_read': 4,   # -> gql_query_restricted_*
-        }
-        
-        suffix = suffix_map.get(perm_type, 9)
+        suffix = cls.PERM_TYPE_SUFFIX[perm_type]
         
         # Start from base and find next available with correct suffix
         candidate = cls.GRIEVANCE_RIGHT_BASE + suffix
@@ -204,4 +170,79 @@ class GrievanceRightsManager:
         if candidate > cls.GRIEVANCE_RIGHT_MAX:
             raise ValueError(f"No available ID for permission type {perm_type}")
             
-        return candidate  
+        return candidate
+    
+    @staticmethod
+    def truncate_with_template(template, variable, max_length):
+        """Generate string from template, truncating variable if needed"""
+        base = template.format(variable=variable)
+        if len(base) <= max_length:
+            return base
+        
+        # Calculate space available for variable
+        prefix_suffix_len = len(template.format(variable=''))
+        max_var_len = max_length - prefix_suffix_len
+        truncated_var = variable[:max_var_len]
+        return template.format(variable=truncated_var)
+    
+    @classmethod
+    def clean_name(cls, name):
+        """Remove parentheses and their contents from a name"""
+        return cls.PARENTHESES_CONTENT_RE.sub('', name).strip()
+
+    @classmethod
+    def generate_safe_name(cls, name):
+        """
+        Generate a safe name suitable for use in codenames.
+        
+        Args:
+            name: The original category or flag name
+            
+        Returns:
+            str: The sanitized safe name
+        """
+        cleaned = cls.clean_name(name)
+        # First convert to lowercase, then replace any non-alphanumeric character with underscore
+        return cls.NON_ALPHANUMERIC_RE.sub('_', cleaned.lower())
+
+    @classmethod
+    def _generate_permission_fields(cls, perm_type, original_name, is_flag=False):
+        """
+        Generate permission fields with proper length limits for Django.
+        
+        Args:
+            perm_type: The permission type (e.g., 'read', 'create')
+            original_name: The original unsanitized name for the permission description
+            is_flag: Whether this is for a flag (True) or category (False)
+            
+        Returns:
+            tuple: (codename, permission_name, right_name) where:
+                - codename is limited to 100 chars
+                - permission_name is limited to 255 chars
+                - right_name is the OpenIMIS permission name
+        """
+        perm_type_display = perm_type.replace('_', ' ')
+        safe_name = cls.generate_safe_name(original_name)
+        
+        # Generate templates based on whether it's a flag or category
+        ticket_suffix = "flagged tickets" if is_flag else "tickets"
+        right_suffix = "flagged_tickets_perms" if is_flag else "category_tickets_perms"
+        
+        # Build codename template
+        if is_flag:
+            codename_template = f"{perm_type}_flag_{{variable}}_grievance"
+        else:
+            codename_template = f"{perm_type}_{{variable}}_grievance"
+        
+        # Build permission name template
+        name_template = f"Can {perm_type_display} {{variable}} {ticket_suffix}"
+        
+        # Generate right name using mapping
+        prefix = cls.PERM_TYPE_MAPPING[perm_type]
+        right_name = f"{prefix}_{safe_name}_{right_suffix}" if prefix else ''
+        
+        # Generate final codename and permission name with truncation
+        codename = cls.truncate_with_template(codename_template, safe_name, cls.CODENAME_MAX_LENGTH)
+        permission_name = cls.truncate_with_template(name_template, cls.clean_name(original_name), cls.PERMISSION_NAME_MAX_LENGTH)
+        
+        return codename, permission_name, right_name

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -18,11 +18,11 @@ class GrievanceRightsManager:
     # Reserve 127100-127999 for dynamic grievance permissions
     GRIEVANCE_RIGHT_BASE = 127100
     GRIEVANCE_RIGHT_MAX = 127999
-    
+
     # Permission fields limits
     CODENAME_MAX_LENGTH = 100
     PERMISSION_NAME_MAX_LENGTH = 255
-    
+
     # Permission type mappings
     PERM_TYPE_MAPPING = {
         'restricted_read': 'gql_query_restricted',
@@ -31,7 +31,7 @@ class GrievanceRightsManager:
         'update': 'gql_mutation_update',
         'delete': 'gql_mutation_delete'
     }
-    
+
     # Permission ID suffix mapping
     PERM_TYPE_SUFFIX = {
         'read': 0,
@@ -40,7 +40,7 @@ class GrievanceRightsManager:
         'delete': 3,
         'restricted_read': 4,
     }
-    
+
     # Regular expressions
     PARENTHESES_CONTENT_RE = re.compile(r'\s*\([^)]*\)')
     NON_ALPHANUMERIC_RE = re.compile(r'[^a-z0-9_]')
@@ -49,7 +49,7 @@ class GrievanceRightsManager:
     def _process_permissions(cls, item_name, item_info, is_flag, existing_by_codename, used_ids, ct, all_rights):
         """
         Process permissions for a single category or flag.
-        
+
         Args:
             item_name: Name of the category or flag
             item_info: Dictionary containing item configuration
@@ -61,13 +61,13 @@ class GrievanceRightsManager:
         """
         permissions = item_info.get('permissions', [])
         item_info['generated_rights'] = {}
-        
+
         for perm_type in permissions:
             # Generate codename with length limit
             codename, permission_name, right_name = cls._generate_permission_fields(
                 perm_type, item_name, is_flag=is_flag
             )
-            
+
             # Check if permission already exists
             if codename in existing_by_codename:
                 perm = existing_by_codename[codename]
@@ -88,7 +88,7 @@ class GrievanceRightsManager:
                 item_info['generated_rights'][perm_type] = perm.id
                 used_ids.add(new_id)
                 logger.info(f"Created new permission: {codename} (ID: {new_id})")
-            
+
             all_rights[right_name] = item_info['generated_rights'][perm_type]
 
     @classmethod
@@ -160,30 +160,30 @@ class GrievanceRightsManager:
     @classmethod
     def _get_next_available_id(cls, perm_type, used_ids):
         suffix = cls.PERM_TYPE_SUFFIX[perm_type]
-        
+
         # Start from base and find next available with correct suffix
         candidate = cls.GRIEVANCE_RIGHT_BASE + suffix
         while candidate in used_ids and candidate <= cls.GRIEVANCE_RIGHT_MAX:
             candidate += 10  # Maintain suffix while incrementing
-            
+
         if candidate > cls.GRIEVANCE_RIGHT_MAX:
             raise ValueError(f"No available ID for permission type {perm_type}")
-            
+
         return candidate
-    
+
     @staticmethod
     def truncate_with_template(template, variable, max_length):
         """Generate string from template, truncating variable if needed"""
         base = template.format(variable=variable)
         if len(base) <= max_length:
             return base
-        
+
         # Calculate space available for variable
         prefix_suffix_len = len(template.format(variable=''))
         max_var_len = max_length - prefix_suffix_len
         truncated_var = variable[:max_var_len]
         return template.format(variable=truncated_var)
-    
+
     @classmethod
     def clean_name(cls, name):
         """Remove parentheses and their contents from a name"""
@@ -193,10 +193,10 @@ class GrievanceRightsManager:
     def generate_safe_name(cls, name):
         """
         Generate a safe name suitable for use in codenames.
-        
+
         Args:
             name: The original category or flag name
-            
+
         Returns:
             str: The sanitized safe name
         """
@@ -208,12 +208,12 @@ class GrievanceRightsManager:
     def _generate_permission_fields(cls, perm_type, original_name, is_flag=False):
         """
         Generate permission fields with proper length limits for Django.
-        
+
         Args:
             perm_type: The permission type (e.g., 'read', 'create')
             original_name: The original unsanitized name for the permission description
             is_flag: Whether this is for a flag (True) or category (False)
-            
+
         Returns:
             tuple: (codename, permission_name, right_name) where:
                 - codename is limited to 100 chars
@@ -222,26 +222,27 @@ class GrievanceRightsManager:
         """
         perm_type_display = perm_type.replace('_', ' ')
         safe_name = cls.generate_safe_name(original_name)
-        
+
         # Generate templates based on whether it's a flag or category
         ticket_suffix = "flagged tickets" if is_flag else "tickets"
         right_suffix = "flagged_tickets_perms" if is_flag else "category_tickets_perms"
-        
+
         # Build codename template
         if is_flag:
             codename_template = f"{perm_type}_flag_{{variable}}_grievance"
         else:
             codename_template = f"{perm_type}_{{variable}}_grievance"
-        
+
         # Build permission name template
         name_template = f"Can {perm_type_display} {{variable}} {ticket_suffix}"
-        
+
         # Generate right name using mapping
         prefix = cls.PERM_TYPE_MAPPING[perm_type]
         right_name = f"{prefix}_{safe_name}_{right_suffix}" if prefix else ''
-        
+
         # Generate final codename and permission name with truncation
         codename = cls.truncate_with_template(codename_template, safe_name, cls.CODENAME_MAX_LENGTH)
-        permission_name = cls.truncate_with_template(name_template, cls.clean_name(original_name).replace('|', ' '), cls.PERMISSION_NAME_MAX_LENGTH)
-        
+        permission_name = cls.truncate_with_template(name_template, cls.clean_name(
+            original_name).replace('|', ' '), cls.PERMISSION_NAME_MAX_LENGTH)
+
         return codename, permission_name, right_name

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -242,6 +242,6 @@ class GrievanceRightsManager:
         
         # Generate final codename and permission name with truncation
         codename = cls.truncate_with_template(codename_template, safe_name, cls.CODENAME_MAX_LENGTH)
-        permission_name = cls.truncate_with_template(name_template, cls.clean_name(original_name), cls.PERMISSION_NAME_MAX_LENGTH)
+        permission_name = cls.truncate_with_template(name_template, cls.clean_name(original_name).replace('|', ' '), cls.PERMISSION_NAME_MAX_LENGTH)
         
         return codename, permission_name, right_name

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -217,7 +217,9 @@ class GrievanceRightsManager:
         """
         cleaned = cls.clean_name(name)
         # First convert to lowercase, then replace any non-alphanumeric character with underscore
-        return cls.NON_ALPHANUMERIC_RE.sub('_', cleaned.lower())
+        result = cls.NON_ALPHANUMERIC_RE.sub('_', cleaned.lower())
+        # Collapse consecutive underscores
+        return re.sub(r'_+', '_', result).strip('_')
 
     @classmethod
     def _generate_permission_fields(cls, perm_type, original_name, is_flag=False):
@@ -258,6 +260,6 @@ class GrievanceRightsManager:
         # Generate final codename and permission name with truncation
         codename = cls.truncate_with_template(codename_template, safe_name, cls.CODENAME_MAX_LENGTH)
         permission_name = cls.truncate_with_template(name_template, cls.clean_name(
-            original_name).replace('|', ' '), cls.PERMISSION_NAME_MAX_LENGTH)
+            original_name), cls.PERMISSION_NAME_MAX_LENGTH)
 
         return codename, permission_name, right_name

--- a/grievance_social_protection/rights.py
+++ b/grievance_social_protection/rights.py
@@ -6,6 +6,7 @@ import re
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from .apps import DEFAULT_CFG
 from .models import Ticket
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,7 @@ class GrievanceRightsManager:
             
             # Set as class attribute
             for right_name, right_ids in grouped_rights.items():
+                DEFAULT_CFG[right_name] = right_ids
                 setattr(app_config, right_name, right_ids)
 
     @classmethod

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -117,10 +117,6 @@ class Query(graphene.ObjectType):
 
         query = Ticket.objects.filter(*filters).all()
         
-        # Apply category and flag permission filtering
-        from .access_control import GrievanceAccessControl
-        query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
-
         return gql_optimizer.query(query, info)
 
     # def resolve_claim_attachments(self, info, **kwargs):

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -54,9 +54,14 @@ class Query(graphene.ObjectType):
     def resolve_ticket_details(self, info, **kwargs):
         if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):
             raise PermissionDenied(_("unauthorized"))
-        return gql_optimizer.query(
-            Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('ticket_title', ), info
-        )
+        
+        query = Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('ticket_title', )
+        
+        # Apply category and flag permission filtering
+        from .access_control import GrievanceAccessControl
+        query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
+        
+        return gql_optimizer.query(query, info)
 
     def resolve_tickets(self, info, **kwargs):
         """
@@ -82,6 +87,10 @@ class Query(graphene.ObjectType):
         else:
             query = model.objects.filter(*filters, is_deleted=False).all()
 
+        # Apply category and flag permission filtering
+        from .access_control import GrievanceAccessControl
+        query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
+
         return gql_optimizer.query(query, info)
 
     def resolve_ticketsStr(self, info, **kwargs):
@@ -106,7 +115,13 @@ class Query(graphene.ObjectType):
         # if str is not None:
         #     filters += [Q(code__icontains=str) | Q(name__icontains=str)]
 
-        return gql_optimizer.query(Ticket.objects.filter(*filters).all(), info)
+        query = Ticket.objects.filter(*filters).all()
+        
+        # Apply category and flag permission filtering
+        from .access_control import GrievanceAccessControl
+        query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
+
+        return gql_optimizer.query(query, info)
 
     # def resolve_claim_attachments(self, info, **kwargs):
     #     if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -115,7 +115,10 @@ class Query(graphene.ObjectType):
         #     filters += [Q(code__icontains=str) | Q(name__icontains=str)]
 
         query = Ticket.objects.filter(*filters).all()
-        
+
+        # Apply category and flag permission filtering
+        query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
+
         return gql_optimizer.query(query, info)
 
     # def resolve_claim_attachments(self, info, **kwargs):

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -8,6 +8,7 @@ import graphene_django_optimizer as gql_optimizer
 
 from core.utils import append_validity_filter
 from .apps import MODULE_NAME
+from .access_control import GrievanceAccessControl
 
 from .gql_queries import *
 from .gql_mutations import *
@@ -58,7 +59,6 @@ class Query(graphene.ObjectType):
         query = Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('ticket_title', )
         
         # Apply category and flag permission filtering
-        from .access_control import GrievanceAccessControl
         query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
         
         return gql_optimizer.query(query, info)
@@ -88,7 +88,6 @@ class Query(graphene.ObjectType):
             query = model.objects.filter(*filters, is_deleted=False).all()
 
         # Apply category and flag permission filtering
-        from .access_control import GrievanceAccessControl
         query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
 
         return gql_optimizer.query(query, info)

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -64,7 +64,7 @@ class Query(graphene.ObjectType):
         if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):
             raise PermissionDenied(_("unauthorized"))
 
-        query = Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('ticket_title', )
+        query = Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('title')
 
         # Apply category and flag permission filtering
         query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)

--- a/grievance_social_protection/schema.py
+++ b/grievance_social_protection/schema.py
@@ -10,10 +10,18 @@ from core.utils import append_validity_filter
 from .apps import MODULE_NAME
 from .access_control import GrievanceAccessControl
 
-from .gql_queries import *
-from .gql_mutations import *
+from .gql_queries import (
+    TicketGQLType, CommentGQLType, GrievanceTypeConfigurationGQLType,
+)
+from .gql_mutations import (
+    CreateTicketMutation, UpdateTicketMutation, DeleteTicketMutation,
+    CreateCommentMutation, ResolveGrievanceByCommentMutation, ReopenTicketMutation,
+)
+from .models import Ticket, Comment, TicketMutation
+from .apps import TicketConfig
+from .validations import user_associated_with_ticket
+from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy as _
-
 
 
 class Query(graphene.ObjectType):
@@ -55,12 +63,12 @@ class Query(graphene.ObjectType):
     def resolve_ticket_details(self, info, **kwargs):
         if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):
             raise PermissionDenied(_("unauthorized"))
-        
+
         query = Ticket.objects.filter(*append_validity_filter(**kwargs)).all().order_by('ticket_title', )
-        
+
         # Apply category and flag permission filtering
         query = GrievanceAccessControl.filter_ticket_queryset(query, info.context.user)
-        
+
         return gql_optimizer.query(query, info)
 
     def resolve_tickets(self, info, **kwargs):
@@ -124,7 +132,6 @@ class Query(graphene.ObjectType):
     # def resolve_claim_attachments(self, info, **kwargs):
     #     if not info.context.user.has_perms(TicketConfig.gql_query_tickets_perms):
     #         raise PermissionDenied(_("unauthorized"))
-
 
     def resolve_grievance_config(self, info, **kwargs):
         user = info.context.user

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -26,7 +26,7 @@ class TicketService(BaseService):
     def create(self, obj_data):
         self._get_content_type(obj_data)
         self._generate_code(obj_data)
-        self._validate_access_control(obj_data)
+        self._validate_access_control(obj_data, access_type='create')
         self._apply_category_defaults(obj_data)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
@@ -36,7 +36,8 @@ class TicketService(BaseService):
     @register_service_signal('ticket_service.update')
     def update(self, obj_data):
         self._get_content_type(obj_data)
-        self._validate_access_control(obj_data)
+        self._validate_existing_ticket_access(obj_data, access_type='update')
+        self._validate_access_control(obj_data, access_type='update')
         self._apply_category_defaults(obj_data)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
@@ -45,7 +46,25 @@ class TicketService(BaseService):
 
     @register_service_signal('ticket_service.delete')
     def delete(self, obj_data):
+        self._validate_existing_ticket_access(obj_data, access_type='delete')
         return super().delete(obj_data)
+
+    def _validate_existing_ticket_access(self, obj_data, access_type):
+        """Validate user has permission for the existing ticket's category and flags"""
+        ticket_uuid = obj_data.get('uuid') or obj_data.get('id')
+        if not ticket_uuid:
+            return
+
+        ticket = Ticket.objects.filter(uuid=ticket_uuid).first()
+        if not ticket:
+            return
+
+        try:
+            GrievanceAccessControl.validate_ticket_access(
+                self.user, ticket.category, ticket.flags, access_type
+            )
+        except PermissionDenied as e:
+            raise ValidationError(str(e))
 
     @register_service_signal('ticket_service.reopen_ticket')
     @check_authentication
@@ -90,13 +109,13 @@ class TicketService(BaseService):
             new_ticket_code = f'GRS{last_ticket_code_numeric + 1:08}'
             obj_data['code'] = new_ticket_code
     
-    def _validate_access_control(self, obj_data):
+    def _validate_access_control(self, obj_data, access_type='create'):
         """Validate user has permission to use selected category and flags"""
         category = obj_data.get('category')
         flags = obj_data.get('flags')
-        
+
         try:
-            GrievanceAccessControl.validate_ticket_access(self.user, category, flags)
+            GrievanceAccessControl.validate_ticket_access(self.user, category, flags, access_type)
         except PermissionDenied as e:
             raise ValidationError(str(e))
     
@@ -115,7 +134,7 @@ class TicketService(BaseService):
             obj_data['flags'] = ' '.join(default_flags)
         elif default_flags and obj_data.get('flags'):
             # Ensure default flags are included
-            existing_flags = obj_data['flags'].split() if isinstance(obj_data['flags'], str) else []
+            existing_flags = GrievanceAccessControl.parse_flags(obj_data['flags'])
             for flag in default_flags:
                 if flag not in existing_flags:
                     existing_flags.append(flag)

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -28,6 +28,8 @@ class TicketService(BaseService):
         self._generate_code(obj_data)
         self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_CREATE)
         self._apply_category_defaults(obj_data)
+        # Re-validate after defaults may have added restricted flags
+        self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_CREATE)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
             raise ValidationError(resolution_error)
@@ -39,6 +41,8 @@ class TicketService(BaseService):
         self._validate_existing_ticket_access(obj_data, access_type=GrievanceAccessControl.PERM_UPDATE)
         self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_UPDATE)
         self._apply_category_defaults(obj_data)
+        # Re-validate after defaults may have added restricted flags
+        self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_UPDATE)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
             raise ValidationError(resolution_error)
@@ -60,11 +64,15 @@ class TicketService(BaseService):
 
     def _validate_existing_ticket_access(self, obj_data, access_type):
         """Validate user has permission for the existing ticket's category and flags"""
-        ticket_uuid = obj_data.get('uuid') or obj_data.get('id')
-        if not ticket_uuid:
+        ticket_uuid = obj_data.get('uuid')
+        ticket_id = obj_data.get('id')
+        if not ticket_uuid and not ticket_id:
             return
 
-        ticket = Ticket.objects.filter(uuid=ticket_uuid).first()
+        if ticket_uuid:
+            ticket = Ticket.objects.filter(uuid=ticket_uuid).first()
+        else:
+            ticket = Ticket.objects.filter(id=ticket_id).first()
         if not ticket:
             return
 

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -128,6 +128,13 @@ class TicketService(BaseService):
 
     def _validate_access_control(self, obj_data, access_type=GrievanceAccessControl.PERM_CREATE):
         """Validate user has permission to use selected category and flags"""
+        category = obj_data.get('category')
+        if category and TicketConfig.processed_categories:
+            if category not in TicketConfig.processed_categories:
+                raise ValidationError(
+                    f"Unknown category: '{category}'. "
+                    f"Must be one of the configured grievance types."
+                )
         self._check_access_or_raise(
             obj_data.get('category'), obj_data.get('flags'), access_type
         )

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -26,7 +26,7 @@ class TicketService(BaseService):
     def create(self, obj_data):
         self._get_content_type(obj_data)
         self._generate_code(obj_data)
-        self._validate_access_control(obj_data, access_type='create')
+        self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_CREATE)
         self._apply_category_defaults(obj_data)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
@@ -36,8 +36,8 @@ class TicketService(BaseService):
     @register_service_signal('ticket_service.update')
     def update(self, obj_data):
         self._get_content_type(obj_data)
-        self._validate_existing_ticket_access(obj_data, access_type='update')
-        self._validate_access_control(obj_data, access_type='update')
+        self._validate_existing_ticket_access(obj_data, access_type=GrievanceAccessControl.PERM_UPDATE)
+        self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_UPDATE)
         self._apply_category_defaults(obj_data)
         resolution_error = validate_resolution(obj_data)
         if resolution_error:
@@ -46,7 +46,7 @@ class TicketService(BaseService):
 
     @register_service_signal('ticket_service.delete')
     def delete(self, obj_data):
-        self._validate_existing_ticket_access(obj_data, access_type='delete')
+        self._validate_existing_ticket_access(obj_data, access_type=GrievanceAccessControl.PERM_DELETE)
         return super().delete(obj_data)
 
     def _check_access_or_raise(self, category, flags, access_type):
@@ -113,7 +113,7 @@ class TicketService(BaseService):
             new_ticket_code = f'GRS{last_ticket_code_numeric + 1:08}'
             obj_data['code'] = new_ticket_code
     
-    def _validate_access_control(self, obj_data, access_type='create'):
+    def _validate_access_control(self, obj_data, access_type=GrievanceAccessControl.PERM_CREATE):
         """Validate user has permission to use selected category and flags"""
         self._check_access_or_raise(
             obj_data.get('category'), obj_data.get('flags'), access_type

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -75,13 +75,14 @@ class TicketService(BaseService):
             return
 
         ticket = None
+        base_qs = Ticket.filter_queryset()
         if ticket_uuid:
-            ticket = Ticket.objects.filter(uuid=ticket_uuid).first()
+            ticket = base_qs.filter(uuid=ticket_uuid).first()
         if not ticket and ticket_id:
             if isinstance(ticket_id, int) or (isinstance(ticket_id, str) and ticket_id.isdigit()):
-                ticket = Ticket.objects.filter(id=ticket_id).first()
+                ticket = base_qs.filter(id=ticket_id).first()
             else:
-                ticket = Ticket.objects.filter(uuid=ticket_id).first()
+                ticket = base_qs.filter(uuid=ticket_id).first()
         if not ticket:
             raise ValidationError("Ticket does not exist.")
 

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -14,6 +14,7 @@ from grievance_social_protection.validations import (
     validate_resolution
 )
 from grievance_social_protection.access_control import GrievanceAccessControl
+from grievance_social_protection.apps import TicketConfig
 
 
 class TicketService(BaseService):
@@ -26,6 +27,10 @@ class TicketService(BaseService):
     def create(self, obj_data):
         self._get_content_type(obj_data)
         self._generate_code(obj_data)
+        # Assign default category before access control so permission
+        # checks always have a category to validate against.
+        if not obj_data.get('category'):
+            obj_data['category'] = TicketConfig.default_grievance_type
         self._validate_access_control(obj_data, access_type=GrievanceAccessControl.PERM_CREATE)
         self._apply_category_defaults(obj_data)
         # Re-validate after defaults may have added restricted flags

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -74,12 +74,16 @@ class TicketService(BaseService):
         if not ticket_uuid and not ticket_id:
             return
 
+        ticket = None
         if ticket_uuid:
             ticket = Ticket.objects.filter(uuid=ticket_uuid).first()
-        else:
-            ticket = Ticket.objects.filter(id=ticket_id).first()
+        if not ticket and ticket_id:
+            if isinstance(ticket_id, int) or (isinstance(ticket_id, str) and ticket_id.isdigit()):
+                ticket = Ticket.objects.filter(id=ticket_id).first()
+            else:
+                ticket = Ticket.objects.filter(uuid=ticket_id).first()
         if not ticket:
-            return
+            raise ValidationError("Ticket does not exist.")
 
         self._check_access_or_raise(ticket.category, ticket.flags, access_type)
 
@@ -135,6 +139,15 @@ class TicketService(BaseService):
                     f"Unknown category: '{category}'. "
                     f"Must be one of the configured grievance types."
                 )
+        flags = obj_data.get('flags')
+        if flags and TicketConfig.grievance_flags:
+            flag_list = GrievanceAccessControl.parse_flags(flags)
+            for flag in flag_list:
+                if flag not in TicketConfig.grievance_flags:
+                    raise ValidationError(
+                        f"Unknown flag: '{flag}'. "
+                        f"Must be one of the configured grievance flags."
+                    )
         self._check_access_or_raise(
             obj_data.get('category'), obj_data.get('flags'), access_type
         )

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -49,6 +49,15 @@ class TicketService(BaseService):
         self._validate_existing_ticket_access(obj_data, access_type='delete')
         return super().delete(obj_data)
 
+    def _check_access_or_raise(self, category, flags, access_type):
+        """Validate ticket access and convert PermissionDenied to ValidationError"""
+        try:
+            GrievanceAccessControl.validate_ticket_access(
+                self.user, category, flags, access_type
+            )
+        except PermissionDenied as e:
+            raise ValidationError(str(e))
+
     def _validate_existing_ticket_access(self, obj_data, access_type):
         """Validate user has permission for the existing ticket's category and flags"""
         ticket_uuid = obj_data.get('uuid') or obj_data.get('id')
@@ -59,12 +68,7 @@ class TicketService(BaseService):
         if not ticket:
             return
 
-        try:
-            GrievanceAccessControl.validate_ticket_access(
-                self.user, ticket.category, ticket.flags, access_type
-            )
-        except PermissionDenied as e:
-            raise ValidationError(str(e))
+        self._check_access_or_raise(ticket.category, ticket.flags, access_type)
 
     @register_service_signal('ticket_service.reopen_ticket')
     @check_authentication
@@ -111,13 +115,9 @@ class TicketService(BaseService):
     
     def _validate_access_control(self, obj_data, access_type='create'):
         """Validate user has permission to use selected category and flags"""
-        category = obj_data.get('category')
-        flags = obj_data.get('flags')
-
-        try:
-            GrievanceAccessControl.validate_ticket_access(self.user, category, flags, access_type)
-        except PermissionDenied as e:
-            raise ValidationError(str(e))
+        self._check_access_or_raise(
+            obj_data.get('category'), obj_data.get('flags'), access_type
+        )
     
     def _apply_category_defaults(self, obj_data):
         """Apply category defaults (flags, priority) if not already set"""
@@ -130,11 +130,8 @@ class TicketService(BaseService):
         
         # Apply default flags
         default_flags = defaults.get('default_flags', [])
-        if default_flags and not obj_data.get('flags'):
-            obj_data['flags'] = ' '.join(default_flags)
-        elif default_flags and obj_data.get('flags'):
-            # Ensure default flags are included
-            existing_flags = GrievanceAccessControl.parse_flags(obj_data['flags'])
+        if default_flags:
+            existing_flags = GrievanceAccessControl.parse_flags(obj_data.get('flags'))
             for flag in default_flags:
                 if flag not in existing_flags:
                     existing_flags.append(flag)

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -129,8 +129,8 @@ class TicketService(BaseService):
     def _validate_access_control(self, obj_data, access_type=GrievanceAccessControl.PERM_CREATE):
         """Validate user has permission to use selected category and flags"""
         category = obj_data.get('category')
-        if category and TicketConfig.processed_categories:
-            if category not in TicketConfig.processed_categories:
+        if category and TicketConfig.grievance_types:
+            if category not in TicketConfig.grievance_types:
                 raise ValidationError(
                     f"Unknown category: '{category}'. "
                     f"Must be one of the configured grievance types."

--- a/grievance_social_protection/services.py
+++ b/grievance_social_protection/services.py
@@ -112,22 +112,22 @@ class TicketService(BaseService):
 
             new_ticket_code = f'GRS{last_ticket_code_numeric + 1:08}'
             obj_data['code'] = new_ticket_code
-    
+
     def _validate_access_control(self, obj_data, access_type=GrievanceAccessControl.PERM_CREATE):
         """Validate user has permission to use selected category and flags"""
         self._check_access_or_raise(
             obj_data.get('category'), obj_data.get('flags'), access_type
         )
-    
+
     def _apply_category_defaults(self, obj_data):
         """Apply category defaults (flags, priority) if not already set"""
         category = obj_data.get('category')
         if not category:
             return
-        
+
         # Get category defaults
         defaults = GrievanceAccessControl.get_category_defaults(category)
-        
+
         # Apply default flags
         default_flags = defaults.get('default_flags', [])
         if default_flags:
@@ -136,7 +136,7 @@ class TicketService(BaseService):
                 if flag not in existing_flags:
                     existing_flags.append(flag)
             obj_data['flags'] = ' '.join(existing_flags)
-        
+
         # Get effective priority if not set
         if not obj_data.get('priority'):
             obj_data['priority'] = GrievanceAccessControl.get_effective_priority(
@@ -202,7 +202,11 @@ class CommentService:
                     "detail": "resolve_grievance_by_comment",
                 }
         except Exception as exc:
-            return output_exception(model_name=self.OBJECT_TYPE.__name__, method="resolve_grievance_by_comment", exception=exc)
+            return output_exception(
+                model_name=self.OBJECT_TYPE.__name__,
+                method="resolve_grievance_by_comment",
+                exception=exc
+            )
 
     def save_instance(self, obj_):
         obj_.save(user=self.user)

--- a/grievance_social_protection/tests/__init__.py
+++ b/grievance_social_protection/tests/__init__.py
@@ -1,1 +1,1 @@
-from .ticket_service_test import TicketServiceTest
+from .ticket_service_test import TicketServiceTest  # noqa: F401

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -1,0 +1,325 @@
+from django.core.exceptions import PermissionDenied
+from django.test import TestCase
+from core.test_helpers import create_test_interactive_user
+
+from grievance_social_protection.access_control import GrievanceAccessControl
+from grievance_social_protection.apps import TicketConfig
+
+
+class GrievanceAccessControlTest(TestCase):
+    """Test rights-based access control for grievance categories and flags"""
+    
+    user_with_perms = None
+    user_no_perms = None
+    user_limited_perms = None
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        
+        # Create test users with different permission levels
+        cls.user_with_perms = create_test_interactive_user(username='user_all_perms', roles=[7])
+        cls.user_no_perms = create_test_interactive_user(username='user_no_perms', roles=[1])
+        cls.user_limited_perms = create_test_interactive_user(username='user_limited_perms', roles=[1])
+        
+        # Mock has_perm for test users
+        cls.user_with_perms.has_perm = lambda perm: True
+        cls.user_no_perms.has_perm = lambda perm: False
+        cls.user_limited_perms.has_perm = lambda perm: perm in [
+            '127000',  # View tickets
+            '127001',  # Create tickets
+            '127004'   # View comments
+        ]
+    
+    def setUp(self):
+        """Set up test configuration before each test"""
+        self._setup_test_config()
+    
+    def _setup_test_config(self):
+        """Set up test configuration data"""
+        # Create configuration in the format that TicketConfig expects
+        cfg = {
+            'grievance_types': [
+                'simple_category',
+                {
+                    'name': 'complaint',
+                    'priority': 'High',
+                    'permissions': ['127000', '127001'],  # View and create tickets
+                    'default_flags': ['urgent'],
+                    'children': [
+                        {
+                            'name': 'service_complaint',
+                            'permissions': ['127002']  # Update tickets
+                        }
+                    ]
+                },
+                {
+                    'name': 'feedback',
+                    'priority': 'Low',
+                    'permissions': ['127000']  # View tickets
+                },
+                {
+                    'name': 'restricted_category',
+                    'priority': 'Critical',
+                    'permissions': ['127002', '127003'],  # Update and delete tickets
+                    'default_flags': ['sensitive']
+                }
+            ],
+            'grievance_flags': [
+                {
+                    'name': 'urgent',
+                    'priority': 'High'
+                },
+                {
+                    'name': 'sensitive',
+                    'priority': 'Critical',
+                    'permissions': ['127004', '127005']  # View and create comments
+                },
+                'public'
+            ]
+        }
+        
+        # Process the configuration using TicketConfig methods (mimicking ready() method)
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        TicketConfig._TicketConfig__process_unified_flags(cfg)
+        TicketConfig._TicketConfig__load_config(cfg)
+    
+    def test_check_category_permission_no_restrictions(self):
+        """Test category access with no permission restrictions"""
+        # Should allow access for all users when no permissions defined
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_no_perms, 'simple_category'
+        )
+        self.assertTrue(result)
+        
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_with_perms, 'simple_category'
+        )
+        self.assertTrue(result)
+    
+    def test_check_category_permission_with_restrictions(self):
+        """Test category access with permission restrictions"""
+        # User with permissions should have access
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_with_perms, 'complaint'
+        )
+        self.assertTrue(result)
+        
+        # User without permissions should not have access
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_no_perms, 'complaint'
+        )
+        self.assertFalse(result)
+    
+    def test_check_category_permission_inheritance(self):
+        """Test permission inheritance from parent categories"""
+        # Child inherits create permission from parent - user with all perms
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_with_perms, 'complaint|service_complaint'
+        )
+        self.assertTrue(result)
+        
+        # User without permissions should not inherit
+        result = GrievanceAccessControl.check_category_permission(
+            self.user_no_perms, 'complaint|service_complaint'
+        )
+        self.assertFalse(result)
+    
+    def test_check_flag_permission(self):
+        """Test flag permission checking"""
+        # No restrictions
+        result = GrievanceAccessControl.check_flag_permission(
+            self.user_no_perms, 'urgent'
+        )
+        self.assertTrue(result)
+        
+        # With restrictions - user with perms
+        result = GrievanceAccessControl.check_flag_permission(
+            self.user_with_perms, 'sensitive'
+        )
+        self.assertTrue(result)
+        
+        # With restrictions - user without perms
+        result = GrievanceAccessControl.check_flag_permission(
+            self.user_no_perms, 'sensitive'
+        )
+        self.assertFalse(result)
+    
+    def test_get_accessible_categories(self):
+        """Test filtering categories by user permissions"""
+        # User with all permissions
+        accessible = GrievanceAccessControl.get_accessible_categories(
+            self.user_with_perms
+        )
+        self.assertEqual(len(accessible), 5)  # All categories
+        
+        # User with no permissions
+        accessible = GrievanceAccessControl.get_accessible_categories(
+            self.user_no_perms
+        )
+        self.assertEqual(accessible, ['simple_category'])  # Only unrestricted
+    
+    def test_get_category_hierarchy(self):
+        """Test hierarchical category structure generation"""
+        hierarchy = GrievanceAccessControl.get_category_hierarchy(
+            self.user_with_perms
+        )
+        
+        # Should have top-level categories
+        names = [cat['name'] for cat in hierarchy]
+        self.assertIn('complaint', names)
+        self.assertIn('simple_category', names)
+        
+        # Check children
+        complaint = next(cat for cat in hierarchy if cat['name'] == 'complaint')
+        self.assertEqual(len(complaint['children']), 1)
+        self.assertEqual(complaint['children'][0]['name'], 'service_complaint')
+    
+    def test_get_accessible_flags(self):
+        """Test filtering flags by user permissions"""
+        # User with permissions
+        flags = GrievanceAccessControl.get_accessible_flags(self.user_with_perms)
+        self.assertEqual(set(flags), {'urgent', 'sensitive', 'public'})
+        
+        # User without permissions
+        flags = GrievanceAccessControl.get_accessible_flags(self.user_no_perms)
+        self.assertEqual(set(flags), {'urgent', 'public'})  # Only unrestricted
+    
+    def test_validate_ticket_access(self):
+        """Test ticket access validation"""
+        # Should not raise for valid access
+        try:
+            GrievanceAccessControl.validate_ticket_access(
+                self.user_with_perms, 'complaint', 'urgent'
+            )
+        except PermissionDenied:
+            self.fail("validate_ticket_access raised PermissionDenied unexpectedly")
+        
+        # Should raise for invalid category access
+        with self.assertRaises(PermissionDenied) as context:
+            GrievanceAccessControl.validate_ticket_access(
+                self.user_no_perms, 'complaint', None
+            )
+        self.assertIn('complaint', str(context.exception))
+        
+        # Should raise for invalid flag access
+        with self.assertRaises(PermissionDenied) as context:
+            GrievanceAccessControl.validate_ticket_access(
+                self.user_no_perms, 'simple_category', 'sensitive'
+            )
+        self.assertIn('sensitive', str(context.exception))
+    
+    def test_get_category_defaults(self):
+        """Test getting category default values"""
+        defaults = GrievanceAccessControl.get_category_defaults('complaint')
+        self.assertEqual(defaults['priority'], 'High')
+        self.assertEqual(defaults['default_flags'], ['urgent'])
+        
+    
+    def test_get_effective_priority(self):
+        """Test priority calculation from category and flags"""
+        # Category priority
+        priority = GrievanceAccessControl.get_effective_priority('complaint', None)
+        self.assertEqual(priority, 'High')
+        
+        # Flag overrides with higher priority
+        priority = GrievanceAccessControl.get_effective_priority(
+            'simple_category', 'sensitive'
+        )
+        self.assertEqual(priority, 'Critical')
+        
+        # Multiple flags - highest wins
+        priority = GrievanceAccessControl.get_effective_priority(
+            'simple_category', ['urgent', 'public']
+        )
+        self.assertEqual(priority, 'High')
+    
+    def test_backward_compatibility(self):
+        """Test backward compatibility with simple string configurations"""
+        # Reset to simple configuration
+        TicketConfig.processed_categories = {}
+        TicketConfig.processed_flags = {}
+        
+        # Should return all categories when no processed config
+        categories = GrievanceAccessControl.get_accessible_categories(
+            self.user_no_perms
+        )
+        self.assertEqual(categories, TicketConfig.grievance_types)
+        
+        # Should return all flags when no processed config
+        flags = GrievanceAccessControl.get_accessible_flags(self.user_no_perms)
+        self.assertEqual(flags, TicketConfig.grievance_flags)
+    
+    def test_parent_visible_child_restricted_permissions(self):
+        """Test permission checking where parent is accessible but specific child is not"""
+        # Add test configuration for mixed parent-child permissions
+        additional_cfg = {
+            'grievance_types': [
+                {
+                    'name': 'parent_mixed',
+                    'priority': 'Medium',
+                    'permissions': ['127000'],  # View tickets - Limited user has this
+                    'children': [
+                        {
+                            'name': 'accessible_child'
+                            # No permissions - will inherit parent's
+                        },
+                        {
+                            'name': 'restricted_child',
+                            'priority': 'High',
+                            'permissions': ['127006']  # Resolve grievances - Limited user doesn't have this
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        # Process the additional configuration
+        TicketConfig._TicketConfig__process_unified_categories(additional_cfg)
+        
+        # Merge with existing configuration and reload
+        TicketConfig.grievance_types.extend(additional_cfg['grievance_types'])
+        TicketConfig.processed_categories.update(additional_cfg['processed_categories'])
+        
+        # Test parent access
+        self.assertTrue(
+            GrievanceAccessControl.check_category_permission(
+                self.user_limited_perms, 'parent_mixed'
+            )
+        )
+        
+        # Test accessible child (inherits parent permission)
+        self.assertTrue(
+            GrievanceAccessControl.check_category_permission(
+                self.user_limited_perms, 'parent_mixed|accessible_child'
+            )
+        )
+        
+        # Test restricted child (requires different permission)
+        self.assertFalse(
+            GrievanceAccessControl.check_category_permission(
+                self.user_limited_perms, 'parent_mixed|restricted_child'
+            )
+        )
+        
+        # User with all permissions should access everything
+        self.assertTrue(
+            GrievanceAccessControl.check_category_permission(
+                self.user_with_perms, 'parent_mixed|restricted_child'
+            )
+        )
+        
+        # Test hierarchy retrieval
+        hierarchy = GrievanceAccessControl.get_category_hierarchy(
+            self.user_limited_perms
+        )
+        
+        # Find the parent_mixed category in hierarchy
+        parent_mixed = next((cat for cat in hierarchy if cat['name'] == 'parent_mixed'), None)
+        self.assertIsNotNone(parent_mixed)
+        
+        # Should have only one visible child
+        visible_children = parent_mixed.get('children', [])
+        self.assertEqual(len(visible_children), 1)
+        self.assertEqual(visible_children[0]['name'], 'accessible_child')
+    

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -3,48 +3,47 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
-from core.models import Role, RoleRight, UserRole
 
 from grievance_social_protection.access_control import GrievanceAccessControl
 from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.rights import GrievanceRightsManager
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, get_rights, collect_all_rights,
+)
 import grievance_social_protection
 
 class GrievanceAccessControlTest(TestCase):
     """Test automatic rights generation and access control for grievance categories and flags"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        
-        # Create test users
         cls.user_with_all_rights = create_test_interactive_user(username='user_all_rights', roles=[1])
         cls.user_no_rights = create_test_interactive_user(username='user_no_rights', roles=[1])
         cls.user_restricted_viewer = create_test_interactive_user(username='user_restricted', roles=[1])
         cls.user_full_viewer = create_test_interactive_user(username='user_viewer', roles=[1])
         cls.user_manager = create_test_interactive_user(username='user_manager', roles=[1])
-    
+
     def setUp(self):
         """Set up test configuration before each test"""
         self._setup_test_config()
         self._assign_rights_to_users()
-    
+
     def _setup_test_config(self):
         """Set up test configuration data with new permissions format"""
-        # Create configuration with the new permissions format
         cfg = {
             'grievance_types': [
                 'simple_category',
                 {
                     'name': 'complaint',
                     'priority': 'High',
-                    'permissions': ['restricted_read', 'read', 'create', 'update'],  # New format
+                    'permissions': ['restricted_read', 'read', 'create', 'update'],
                     'default_flags': ['urgent'],
                     'children': [
                         {
                             'name': 'service_complaint',
-                            'permissions': ['read', 'create']  # Override parent
+                            'permissions': ['read', 'create']
                         },
                         {
                             'name': 'vbg_complaint',
@@ -56,7 +55,7 @@ class GrievanceAccessControlTest(TestCase):
                 {
                     'name': 'feedback',
                     'priority': 'Low',
-                    'permissions': ['restricted_read', 'read']  # Read only
+                    'permissions': ['restricted_read', 'read']
                 },
                 {
                     'name': 'restricted_category',
@@ -73,144 +72,71 @@ class GrievanceAccessControlTest(TestCase):
                 {
                     'name': 'confidential',
                     'priority': 'Critical',
-                    'permissions': ['read', 'create']  # Restricted flag
+                    'permissions': ['read', 'create']
                 },
                 {
                     'name': 'sensitive',
                     'priority': 'Critical',
-                    'permissions': ['read']  # Read only flag
+                    'permissions': ['read']
                 },
                 'public'
             ]
         }
-        
-        # Process the configuration
-        TicketConfig._TicketConfig__process_unified_categories(cfg)
-        TicketConfig._TicketConfig__process_unified_flags(cfg)
-        TicketConfig._TicketConfig__load_config(cfg)
-        
-        self._rights_generation()
+        setup_grievance_config(cfg)
 
-    def _rights_generation(self):
-        # Generate rights using the real rights manager
-        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
-    
     def _assign_rights_to_users(self):
         """Assign specific rights to test users through roles"""
-        # Create roles for different access levels
-        complaint_rights = TicketConfig.processed_categories.get('complaint', {}).get('generated_rights', {})
-        
-        # Restricted viewer role
-        if self.user_restricted_viewer.i_user and complaint_rights.get('restricted_read'):
-            role_restricted = Role.objects.create(
-                name='TestRestrictedViewer',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
+        complaint_rights = get_rights('processed_categories', 'complaint')
+
+        # Restricted viewer - only restricted_read for complaint
+        if complaint_rights.get('restricted_read'):
+            assign_rights_to_user(
+                self.user_restricted_viewer,
+                [complaint_rights['restricted_read']],
+                'ACRestrictedViewer',
             )
-            RoleRight.objects.create(
-                role=role_restricted,
-                right_id=complaint_rights['restricted_read'],
-                audit_user_id=-1
+
+        # Full viewer - read for complaint
+        if complaint_rights.get('read'):
+            assign_rights_to_user(
+                self.user_full_viewer,
+                [complaint_rights['read']],
+                'ACViewer',
             )
-            UserRole.objects.create(
-                user=self.user_restricted_viewer.i_user,
-                role=role_restricted,
-                audit_user_id=-1
-            )
-        
-        # Full viewer role
-        if self.user_full_viewer.i_user and complaint_rights.get('read'):
-            role_viewer = Role.objects.create(
-                name='TestViewer',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            RoleRight.objects.create(
-                role=role_viewer,
-                right_id=complaint_rights['read'],
-                audit_user_id=-1
-            )
-            UserRole.objects.create(
-                user=self.user_full_viewer.i_user,
-                role=role_viewer,
-                audit_user_id=-1
-            )
-        
-        # Manager role with all rights
-        if self.user_manager.i_user:
-            role_manager = Role.objects.create(
-                name='TestManager',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Add all complaint rights
-            for right_id in complaint_rights.values():
-                RoleRight.objects.create(
-                    role=role_manager,
-                    right_id=right_id,
-                    audit_user_id=-1
-                )
-            UserRole.objects.create(
-                user=self.user_manager.i_user,
-                role=role_manager,
-                audit_user_id=-1
-            )
-        
-        # User with all rights
-        if self.user_with_all_rights.i_user:
-            role_all = Role.objects.create(
-                name='TestAllRights',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Add all generated rights
-            for cat_info in TicketConfig.processed_categories.values():
-                for right_id in cat_info.get('generated_rights', {}).values():
-                    RoleRight.objects.create(
-                        role=role_all,
-                        right_id=right_id,
-                        audit_user_id=-1
-                    )
-            for flag_info in TicketConfig.processed_flags.values():
-                for right_id in flag_info.get('generated_rights', {}).values():
-                    RoleRight.objects.create(
-                        role=role_all,
-                        right_id=right_id,
-                        audit_user_id=-1
-                    )
-            UserRole.objects.create(
-                user=self.user_with_all_rights.i_user,
-                role=role_all,
-                audit_user_id=-1
-            )
-    
+
+        # Manager - all complaint rights
+        assign_rights_to_user(
+            self.user_manager,
+            list(complaint_rights.values()),
+            'ACManager',
+        )
+
+        # User with all rights across all categories and flags
+        all_right_ids = list(collect_all_rights())
+        assign_rights_to_user(
+            self.user_with_all_rights,
+            all_right_ids,
+            'ACAllRights',
+        )
+
     def test_automatic_rights_generation(self):
         """Test that rights are generated for categories with permissions"""
-        # Check complaint category has generated rights
         complaint_info = TicketConfig.processed_categories.get('complaint', {})
         self.assertIn('generated_rights', complaint_info)
-        # All permissions defined in config should be generated
         self.assertIn('restricted_read', complaint_info['generated_rights'])
         self.assertIn('read', complaint_info['generated_rights'])
         self.assertIn('create', complaint_info['generated_rights'])
         self.assertIn('update', complaint_info['generated_rights'])
-        
-        # Check feedback category (read only)
+
         feedback_info = TicketConfig.processed_categories.get('feedback', {})
         self.assertIn('generated_rights', feedback_info)
         self.assertIn('restricted_read', feedback_info['generated_rights'])
         self.assertIn('read', feedback_info['generated_rights'])
-        # No write permissions defined
         self.assertNotIn('create', feedback_info['generated_rights'])
         self.assertNotIn('update', feedback_info['generated_rights'])
-    
+
     def test_check_category_access_with_new_permissions(self):
         """Test category access with new permission system using real rights"""
-        # Test restricted access
         self.assertTrue(
             GrievanceAccessControl.check_category_access(
                 self.user_restricted_viewer, 'complaint', 'restricted_read'
@@ -221,8 +147,7 @@ class GrievanceAccessControlTest(TestCase):
                 self.user_restricted_viewer, 'complaint', 'read'
             )
         )
-        
-        # Test full read access
+
         self.assertTrue(
             GrievanceAccessControl.check_category_access(
                 self.user_full_viewer, 'complaint', 'read'
@@ -233,8 +158,7 @@ class GrievanceAccessControlTest(TestCase):
                 self.user_full_viewer, 'complaint', 'create'
             )
         )
-        
-        # Test manager access
+
         self.assertTrue(
             GrievanceAccessControl.check_category_access(
                 self.user_manager, 'complaint', 'create'
@@ -245,170 +169,143 @@ class GrievanceAccessControlTest(TestCase):
                 self.user_manager, 'complaint', 'update'
             )
         )
-    
+
     def test_get_user_access_level(self):
         """Test determining user's access level with real database rights"""
-        # Restricted viewer
         level = GrievanceAccessControl.get_user_access_level(
             self.user_restricted_viewer, 'complaint'
         )
         self.assertEqual(level, 'restricted')
-        
-        # Full viewer
+
         level = GrievanceAccessControl.get_user_access_level(
             self.user_full_viewer, 'complaint'
         )
         self.assertEqual(level, 'read')
-        
-        # Manager - has create, update, delete permissions so should have 'full' access
+
         level = GrievanceAccessControl.get_user_access_level(
             self.user_manager, 'complaint'
         )
         self.assertEqual(level, 'full')
-        
-        # No access
+
         level = GrievanceAccessControl.get_user_access_level(
             self.user_no_rights, 'complaint'
         )
         self.assertEqual(level, 'none')
-        
-        # Unrestricted category returns 'full'
+
         level = GrievanceAccessControl.get_user_access_level(
             self.user_no_rights, 'simple_category'
         )
         self.assertEqual(level, 'full')
-    
+
     def test_validate_ticket_access_new_system(self):
         """Test ticket access validation with new permission system"""
-        # Manager can create tickets
         try:
             GrievanceAccessControl.validate_ticket_access(
                 self.user_manager, 'complaint', None, 'create'
             )
         except PermissionDenied:
             self.fail("validate_ticket_access raised PermissionDenied unexpectedly")
-        
-        # Viewer cannot write
+
         with self.assertRaises(PermissionDenied) as context:
             GrievanceAccessControl.validate_ticket_access(
                 self.user_full_viewer, 'complaint', None, 'create'
             )
         self.assertIn('create', str(context.exception))
-    
+
     def test_get_user_rights(self):
         """Test getting user rights from database"""
-        # Manager should have all complaint rights
         manager_rights = set(self.user_manager.rights) if self.user_manager.rights else set()
-        complaint_rights = TicketConfig.processed_categories.get('complaint', {}).get('generated_rights', {})
-        
+        complaint_rights = get_rights('processed_categories', 'complaint')
+
         for right_id in complaint_rights.values():
             self.assertIn(right_id, manager_rights)
-        
-        # User with no grievance-specific rights should not have complaint rights
+
         no_rights = set(self.user_no_rights.rights) if self.user_no_rights.rights else set()
-        # Check that user doesn't have any of the complaint-specific rights
         for right_id in complaint_rights.values():
             self.assertNotIn(right_id, no_rights)
-    
+
     def test_permission_inheritance_with_overrides(self):
         """Test that child categories can override parent permissions"""
-        # service_complaint has only read/write, not update
         service_info = TicketConfig.processed_categories.get('complaint|service_complaint', {})
         rights = service_info.get('generated_rights', {})
-        
+
         self.assertIn('read', rights)
         self.assertIn('create', rights)
-        self.assertNotIn('update', rights)  # Parent has update, but child doesn't
-    
+        self.assertNotIn('update', rights)
+
     def test_get_accessible_categories_with_min_access(self):
         """Test getting accessible categories with minimum access level"""
-        # User with restricted access
         categories = GrievanceAccessControl.get_accessible_categories(
             self.user_restricted_viewer
         )
         self.assertIn('complaint', categories)
-    
+
     def test_empty_permissions_means_no_restrictions(self):
         """Test that categories/flags without permissions have no access restrictions"""
-        # simple_category has no permissions defined - should return True (no restrictions)
         self.assertTrue(
             GrievanceAccessControl.check_category_access(
                 self.user_no_rights, 'simple_category', 'read'
             )
         )
-        
-        # public flag has no permissions - should return True (no restrictions)
+
         self.assertTrue(
             GrievanceAccessControl.check_flag_access(
                 self.user_no_rights, 'public', 'read'
             )
         )
-    
+
     def test_filter_ticket_queryset(self):
         """Test filtering queryset based on user rights"""
-        
-        # Create test tickets
         ticket1 = Ticket(
             category='complaint',
             title='Test Complaint',
             code='TEST001'
         )
         ticket1.save(user=self.user_manager.user)
-        
+
         ticket2 = Ticket(
             category='simple_category',
             title='Test Simple',
             code='TEST002'
         )
         ticket2.save(user=self.user_manager.user)
-        
-        # User with no rights should only see unrestricted tickets
+
         queryset = Ticket.objects.all()
         filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_no_rights)
-        
-        # Should only see simple_category ticket
+
         self.assertIn(ticket2, filtered)
         self.assertNotIn(ticket1, filtered)
-        
-        # User with restricted access should see both
+
         filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_restricted_viewer)
-        self.assertGreaterEqual(filtered.count(), 2)  # At least our 2 tickets
-        
-        # Clean up
+        self.assertGreaterEqual(filtered.count(), 2)
+
         ticket1.delete(user=self.user_manager.user)
         ticket2.delete(user=self.user_manager.user)
 
 
 class GrievanceRightsManagerTest(TestCase):
     """Test automatic rights generation functionality"""
-    
+
     def test_get_next_available_id(self):
         """Test the internal ID generation logic"""
-        # Test that the suffix pattern is maintained
         used_ids = set()
-        
-        # Test read permission (suffix 0)
+
         next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
         self.assertEqual(next_id % 10, 0)
         self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0)
-        
-        # Test create permission (suffix 1)
+
         next_id = GrievanceRightsManager._get_next_available_id('create', used_ids)
         self.assertEqual(next_id % 10, 1)
         self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 1)
-        
-        # Test with some used IDs
+
         used_ids = {127100, 127101, 127102}
         next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
-        self.assertEqual(next_id, 127110)  # Next available with suffix 0
-    
+        self.assertEqual(next_id, 127110)
+
     def test_generate_automatic_rights_integration(self):
         """Test the actual rights generation process"""
-        
-        # Create a mock app config with proper module
         app_config = TicketConfig('grievance_social_protection', grievance_social_protection)
-        
-        # Set up test configuration
+
         app_config.processed_categories = {
             'test_category': {
                 'permissions': ['read', 'create', 'update']
@@ -419,31 +316,25 @@ class GrievanceRightsManagerTest(TestCase):
                 'permissions': ['read']
             }
         }
-        
-        # Count permissions before
+
         ct = ContentType.objects.get_for_model(Ticket)
         perms_before = Permission.objects.filter(
             content_type=ct,
             id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
         ).count()
-        
-        # Generate rights
+
         GrievanceRightsManager.generate_automatic_rights(app_config)
-        
-        # Check that permissions were created
+
         perms_after = Permission.objects.filter(
             content_type=ct,
             id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
         ).count()
-        
-        # Should have created at least some permissions
+
         self.assertGreaterEqual(perms_after, perms_before)
-        
-        # Check that generated_rights were populated
+
         self.assertIn('generated_rights', app_config.processed_categories['test_category'])
         self.assertIn('generated_rights', app_config.processed_flags['test_flag'])
-        
-        # Clean up created permissions
+
         Permission.objects.filter(
             content_type=ct,
             codename__endswith='_grievance',

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -9,7 +9,8 @@ from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.rights import GrievanceRightsManager
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, get_rights, collect_all_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, get_rights, collect_all_rights,
 )
 import grievance_social_protection
 
@@ -28,8 +29,11 @@ class GrievanceAccessControlTest(TestCase):
 
     def setUp(self):
         """Set up test configuration before each test"""
-        self._setup_test_config()
+        self._snapshot = self._setup_test_config()
         self._assign_rights_to_users()
+
+    def tearDown(self):
+        restore_grievance_config(self._snapshot)
 
     def _setup_test_config(self):
         """Set up test configuration data with new permissions format"""
@@ -83,7 +87,7 @@ class GrievanceAccessControlTest(TestCase):
                 'public'
             ]
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     def _assign_rights_to_users(self):
         """Assign specific rights to test users through roles"""
@@ -227,7 +231,7 @@ class GrievanceAccessControlTest(TestCase):
 
     def test_permission_inheritance_with_overrides(self):
         """Test that child categories can override parent permissions"""
-        service_info = TicketConfig.processed_categories.get('complaint|service_complaint', {})
+        service_info = TicketConfig.processed_categories.get('complaint > service_complaint', {})
         rights = service_info.get('generated_rights', {})
 
         self.assertIn('read', rights)

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -324,27 +324,21 @@ class GrievanceAccessControlTest(TestCase):
         """Test getting accessible categories with minimum access level"""
         # User with restricted access
         categories = GrievanceAccessControl.get_accessible_categories(
-            self.user_restricted_viewer, 'restricted_read'
+            self.user_restricted_viewer
         )
         self.assertIn('complaint', categories)
-        
-        # Same user with higher requirement
-        categories = GrievanceAccessControl.get_accessible_categories(
-            self.user_restricted_viewer, 'read'
-        )
-        self.assertNotIn('complaint', categories)
     
     def test_empty_permissions_means_no_restrictions(self):
         """Test that categories/flags without permissions have no access restrictions"""
-        # simple_category has no permissions defined
-        self.assertIsNone(
+        # simple_category has no permissions defined - should return True (no restrictions)
+        self.assertTrue(
             GrievanceAccessControl.check_category_access(
                 self.user_no_rights, 'simple_category', 'read'
             )
         )
         
-        # public flag has no permissions
-        self.assertIsNone(
+        # public flag has no permissions - should return True (no restrictions)
+        self.assertTrue(
             GrievanceAccessControl.check_flag_access(
                 self.user_no_rights, 'public', 'read'
             )

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -1,67 +1,67 @@
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
+from core.models import Role, RoleRight, UserRole
 
 from grievance_social_protection.access_control import GrievanceAccessControl
 from grievance_social_protection.apps import TicketConfig
-
+from grievance_social_protection.models import Ticket
+from grievance_social_protection.rights import GrievanceRightsManager
+import grievance_social_protection
 
 class GrievanceAccessControlTest(TestCase):
-    """Test rights-based access control for grievance categories and flags"""
-    
-    user_with_perms = None
-    user_no_perms = None
-    user_limited_perms = None
+    """Test automatic rights generation and access control for grievance categories and flags"""
     
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         
-        # Create test users with different permission levels
-        cls.user_with_perms = create_test_interactive_user(username='user_all_perms', roles=[7])
-        cls.user_no_perms = create_test_interactive_user(username='user_no_perms', roles=[1])
-        cls.user_limited_perms = create_test_interactive_user(username='user_limited_perms', roles=[1])
-        
-        # Mock has_perm for test users
-        cls.user_with_perms.has_perm = lambda perm: True
-        cls.user_no_perms.has_perm = lambda perm: False
-        cls.user_limited_perms.has_perm = lambda perm: perm in [
-            '127000',  # View tickets
-            '127001',  # Create tickets
-            '127004'   # View comments
-        ]
+        # Create test users
+        cls.user_with_all_rights = create_test_interactive_user(username='user_all_rights', roles=[1])
+        cls.user_no_rights = create_test_interactive_user(username='user_no_rights', roles=[1])
+        cls.user_restricted_viewer = create_test_interactive_user(username='user_restricted', roles=[1])
+        cls.user_full_viewer = create_test_interactive_user(username='user_viewer', roles=[1])
+        cls.user_manager = create_test_interactive_user(username='user_manager', roles=[1])
     
     def setUp(self):
         """Set up test configuration before each test"""
         self._setup_test_config()
+        self._assign_rights_to_users()
     
     def _setup_test_config(self):
-        """Set up test configuration data"""
-        # Create configuration in the format that TicketConfig expects
+        """Set up test configuration data with new permissions format"""
+        # Create configuration with the new permissions format
         cfg = {
             'grievance_types': [
                 'simple_category',
                 {
                     'name': 'complaint',
                     'priority': 'High',
-                    'permissions': ['127000', '127001'],  # View and create tickets
+                    'permissions': ['restricted_read', 'read', 'create', 'update'],  # New format
                     'default_flags': ['urgent'],
                     'children': [
                         {
                             'name': 'service_complaint',
-                            'permissions': ['127002']  # Update tickets
+                            'permissions': ['read', 'create']  # Override parent
+                        },
+                        {
+                            'name': 'vbg_complaint',
+                            'permissions': ['read', 'create'],
+                            'default_flags': ['confidential']
                         }
                     ]
                 },
                 {
                     'name': 'feedback',
                     'priority': 'Low',
-                    'permissions': ['127000']  # View tickets
+                    'permissions': ['restricted_read', 'read']  # Read only
                 },
                 {
                     'name': 'restricted_category',
                     'priority': 'Critical',
-                    'permissions': ['127002', '127003'],  # Update and delete tickets
+                    'permissions': ['read', 'create', 'update'],
                     'default_flags': ['sensitive']
                 }
             ],
@@ -71,255 +71,387 @@ class GrievanceAccessControlTest(TestCase):
                     'priority': 'High'
                 },
                 {
+                    'name': 'confidential',
+                    'priority': 'Critical',
+                    'permissions': ['read', 'create']  # Restricted flag
+                },
+                {
                     'name': 'sensitive',
                     'priority': 'Critical',
-                    'permissions': ['127004', '127005']  # View and create comments
+                    'permissions': ['read']  # Read only flag
                 },
                 'public'
             ]
         }
         
-        # Process the configuration using TicketConfig methods (mimicking ready() method)
+        # Process the configuration
         TicketConfig._TicketConfig__process_unified_categories(cfg)
         TicketConfig._TicketConfig__process_unified_flags(cfg)
         TicketConfig._TicketConfig__load_config(cfg)
+        
+        self._rights_generation()
+
+    def _rights_generation(self):
+        # Generate rights using the real rights manager
+        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
     
-    def test_check_category_permission_no_restrictions(self):
-        """Test category access with no permission restrictions"""
-        # Should allow access for all users when no permissions defined
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_no_perms, 'simple_category'
-        )
-        self.assertTrue(result)
+    def _assign_rights_to_users(self):
+        """Assign specific rights to test users through roles"""
+        # Create roles for different access levels
+        complaint_rights = TicketConfig.processed_categories.get('complaint', {}).get('generated_rights', {})
         
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_with_perms, 'simple_category'
-        )
-        self.assertTrue(result)
+        # Restricted viewer role
+        if self.user_restricted_viewer.i_user and complaint_rights.get('restricted_read'):
+            role_restricted = Role.objects.create(
+                name='TestRestrictedViewer',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            RoleRight.objects.create(
+                role=role_restricted,
+                right_id=complaint_rights['restricted_read'],
+                audit_user_id=-1
+            )
+            UserRole.objects.create(
+                user=self.user_restricted_viewer.i_user,
+                role=role_restricted,
+                audit_user_id=-1
+            )
+        
+        # Full viewer role
+        if self.user_full_viewer.i_user and complaint_rights.get('read'):
+            role_viewer = Role.objects.create(
+                name='TestViewer',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            RoleRight.objects.create(
+                role=role_viewer,
+                right_id=complaint_rights['read'],
+                audit_user_id=-1
+            )
+            UserRole.objects.create(
+                user=self.user_full_viewer.i_user,
+                role=role_viewer,
+                audit_user_id=-1
+            )
+        
+        # Manager role with all rights
+        if self.user_manager.i_user:
+            role_manager = Role.objects.create(
+                name='TestManager',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Add all complaint rights
+            for right_id in complaint_rights.values():
+                RoleRight.objects.create(
+                    role=role_manager,
+                    right_id=right_id,
+                    audit_user_id=-1
+                )
+            UserRole.objects.create(
+                user=self.user_manager.i_user,
+                role=role_manager,
+                audit_user_id=-1
+            )
+        
+        # User with all rights
+        if self.user_with_all_rights.i_user:
+            role_all = Role.objects.create(
+                name='TestAllRights',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Add all generated rights
+            for cat_info in TicketConfig.processed_categories.values():
+                for right_id in cat_info.get('generated_rights', {}).values():
+                    RoleRight.objects.create(
+                        role=role_all,
+                        right_id=right_id,
+                        audit_user_id=-1
+                    )
+            for flag_info in TicketConfig.processed_flags.values():
+                for right_id in flag_info.get('generated_rights', {}).values():
+                    RoleRight.objects.create(
+                        role=role_all,
+                        right_id=right_id,
+                        audit_user_id=-1
+                    )
+            UserRole.objects.create(
+                user=self.user_with_all_rights.i_user,
+                role=role_all,
+                audit_user_id=-1
+            )
     
-    def test_check_category_permission_with_restrictions(self):
-        """Test category access with permission restrictions"""
-        # User with permissions should have access
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_with_perms, 'complaint'
-        )
-        self.assertTrue(result)
+    def test_automatic_rights_generation(self):
+        """Test that rights are generated for categories with permissions"""
+        # Check complaint category has generated rights
+        complaint_info = TicketConfig.processed_categories.get('complaint', {})
+        self.assertIn('generated_rights', complaint_info)
+        # All permissions defined in config should be generated
+        self.assertIn('restricted_read', complaint_info['generated_rights'])
+        self.assertIn('read', complaint_info['generated_rights'])
+        self.assertIn('create', complaint_info['generated_rights'])
+        self.assertIn('update', complaint_info['generated_rights'])
         
-        # User without permissions should not have access
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_no_perms, 'complaint'
-        )
-        self.assertFalse(result)
+        # Check feedback category (read only)
+        feedback_info = TicketConfig.processed_categories.get('feedback', {})
+        self.assertIn('generated_rights', feedback_info)
+        self.assertIn('restricted_read', feedback_info['generated_rights'])
+        self.assertIn('read', feedback_info['generated_rights'])
+        # No write permissions defined
+        self.assertNotIn('create', feedback_info['generated_rights'])
+        self.assertNotIn('update', feedback_info['generated_rights'])
     
-    def test_check_category_permission_inheritance(self):
-        """Test permission inheritance from parent categories"""
-        # Child inherits create permission from parent - user with all perms
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_with_perms, 'complaint|service_complaint'
+    def test_check_category_access_with_new_permissions(self):
+        """Test category access with new permission system using real rights"""
+        # Test restricted access
+        self.assertTrue(
+            GrievanceAccessControl.check_category_access(
+                self.user_restricted_viewer, 'complaint', 'restricted_read'
+            )
         )
-        self.assertTrue(result)
+        self.assertFalse(
+            GrievanceAccessControl.check_category_access(
+                self.user_restricted_viewer, 'complaint', 'read'
+            )
+        )
         
-        # User without permissions should not inherit
-        result = GrievanceAccessControl.check_category_permission(
-            self.user_no_perms, 'complaint|service_complaint'
+        # Test full read access
+        self.assertTrue(
+            GrievanceAccessControl.check_category_access(
+                self.user_full_viewer, 'complaint', 'read'
+            )
         )
-        self.assertFalse(result)
+        self.assertFalse(
+            GrievanceAccessControl.check_category_access(
+                self.user_full_viewer, 'complaint', 'create'
+            )
+        )
+        
+        # Test manager access
+        self.assertTrue(
+            GrievanceAccessControl.check_category_access(
+                self.user_manager, 'complaint', 'create'
+            )
+        )
+        self.assertTrue(
+            GrievanceAccessControl.check_category_access(
+                self.user_manager, 'complaint', 'update'
+            )
+        )
     
-    def test_check_flag_permission(self):
-        """Test flag permission checking"""
-        # No restrictions
-        result = GrievanceAccessControl.check_flag_permission(
-            self.user_no_perms, 'urgent'
+    def test_get_user_access_level(self):
+        """Test determining user's access level with real database rights"""
+        # Restricted viewer
+        level = GrievanceAccessControl.get_user_access_level(
+            self.user_restricted_viewer, 'complaint'
         )
-        self.assertTrue(result)
+        self.assertEqual(level, 'restricted')
         
-        # With restrictions - user with perms
-        result = GrievanceAccessControl.check_flag_permission(
-            self.user_with_perms, 'sensitive'
+        # Full viewer
+        level = GrievanceAccessControl.get_user_access_level(
+            self.user_full_viewer, 'complaint'
         )
-        self.assertTrue(result)
+        self.assertEqual(level, 'read')
         
-        # With restrictions - user without perms
-        result = GrievanceAccessControl.check_flag_permission(
-            self.user_no_perms, 'sensitive'
+        # Manager - has create, update, delete permissions so should have 'full' access
+        level = GrievanceAccessControl.get_user_access_level(
+            self.user_manager, 'complaint'
         )
-        self.assertFalse(result)
+        self.assertEqual(level, 'full')
+        
+        # No access
+        level = GrievanceAccessControl.get_user_access_level(
+            self.user_no_rights, 'complaint'
+        )
+        self.assertEqual(level, 'none')
+        
+        # Unrestricted category returns 'full'
+        level = GrievanceAccessControl.get_user_access_level(
+            self.user_no_rights, 'simple_category'
+        )
+        self.assertEqual(level, 'full')
     
-    def test_get_accessible_categories(self):
-        """Test filtering categories by user permissions"""
-        # User with all permissions
-        accessible = GrievanceAccessControl.get_accessible_categories(
-            self.user_with_perms
-        )
-        self.assertEqual(len(accessible), 5)  # All categories
-        
-        # User with no permissions
-        accessible = GrievanceAccessControl.get_accessible_categories(
-            self.user_no_perms
-        )
-        self.assertEqual(accessible, ['simple_category'])  # Only unrestricted
-    
-    def test_get_category_hierarchy(self):
-        """Test hierarchical category structure generation"""
-        hierarchy = GrievanceAccessControl.get_category_hierarchy(
-            self.user_with_perms
-        )
-        
-        # Should have top-level categories
-        names = [cat['name'] for cat in hierarchy]
-        self.assertIn('complaint', names)
-        self.assertIn('simple_category', names)
-        
-        # Check children
-        complaint = next(cat for cat in hierarchy if cat['name'] == 'complaint')
-        self.assertEqual(len(complaint['children']), 1)
-        self.assertEqual(complaint['children'][0]['name'], 'service_complaint')
-    
-    def test_get_accessible_flags(self):
-        """Test filtering flags by user permissions"""
-        # User with permissions
-        flags = GrievanceAccessControl.get_accessible_flags(self.user_with_perms)
-        self.assertEqual(set(flags), {'urgent', 'sensitive', 'public'})
-        
-        # User without permissions
-        flags = GrievanceAccessControl.get_accessible_flags(self.user_no_perms)
-        self.assertEqual(set(flags), {'urgent', 'public'})  # Only unrestricted
-    
-    def test_validate_ticket_access(self):
-        """Test ticket access validation"""
-        # Should not raise for valid access
+    def test_validate_ticket_access_new_system(self):
+        """Test ticket access validation with new permission system"""
+        # Manager can create tickets
         try:
             GrievanceAccessControl.validate_ticket_access(
-                self.user_with_perms, 'complaint', 'urgent'
+                self.user_manager, 'complaint', None, 'create'
             )
         except PermissionDenied:
             self.fail("validate_ticket_access raised PermissionDenied unexpectedly")
         
-        # Should raise for invalid category access
+        # Viewer cannot write
         with self.assertRaises(PermissionDenied) as context:
             GrievanceAccessControl.validate_ticket_access(
-                self.user_no_perms, 'complaint', None
+                self.user_full_viewer, 'complaint', None, 'create'
             )
-        self.assertIn('complaint', str(context.exception))
-        
-        # Should raise for invalid flag access
-        with self.assertRaises(PermissionDenied) as context:
-            GrievanceAccessControl.validate_ticket_access(
-                self.user_no_perms, 'simple_category', 'sensitive'
-            )
-        self.assertIn('sensitive', str(context.exception))
+        self.assertIn('create', str(context.exception))
     
-    def test_get_category_defaults(self):
-        """Test getting category default values"""
-        defaults = GrievanceAccessControl.get_category_defaults('complaint')
-        self.assertEqual(defaults['priority'], 'High')
-        self.assertEqual(defaults['default_flags'], ['urgent'])
+    def test_get_user_rights(self):
+        """Test getting user rights from database"""
+        # Manager should have all complaint rights
+        manager_rights = set(self.user_manager.rights) if self.user_manager.rights else set()
+        complaint_rights = TicketConfig.processed_categories.get('complaint', {}).get('generated_rights', {})
         
+        for right_id in complaint_rights.values():
+            self.assertIn(right_id, manager_rights)
+        
+        # User with no grievance-specific rights should not have complaint rights
+        no_rights = set(self.user_no_rights.rights) if self.user_no_rights.rights else set()
+        # Check that user doesn't have any of the complaint-specific rights
+        for right_id in complaint_rights.values():
+            self.assertNotIn(right_id, no_rights)
     
-    def test_get_effective_priority(self):
-        """Test priority calculation from category and flags"""
-        # Category priority
-        priority = GrievanceAccessControl.get_effective_priority('complaint', None)
-        self.assertEqual(priority, 'High')
+    def test_permission_inheritance_with_overrides(self):
+        """Test that child categories can override parent permissions"""
+        # service_complaint has only read/write, not update
+        service_info = TicketConfig.processed_categories.get('complaint|service_complaint', {})
+        rights = service_info.get('generated_rights', {})
         
-        # Flag overrides with higher priority
-        priority = GrievanceAccessControl.get_effective_priority(
-            'simple_category', 'sensitive'
-        )
-        self.assertEqual(priority, 'Critical')
-        
-        # Multiple flags - highest wins
-        priority = GrievanceAccessControl.get_effective_priority(
-            'simple_category', ['urgent', 'public']
-        )
-        self.assertEqual(priority, 'High')
+        self.assertIn('read', rights)
+        self.assertIn('create', rights)
+        self.assertNotIn('update', rights)  # Parent has update, but child doesn't
     
-    def test_backward_compatibility(self):
-        """Test backward compatibility with simple string configurations"""
-        # Reset to simple configuration
-        TicketConfig.processed_categories = {}
-        TicketConfig.processed_flags = {}
-        
-        # Should return all categories when no processed config
+    def test_get_accessible_categories_with_min_access(self):
+        """Test getting accessible categories with minimum access level"""
+        # User with restricted access
         categories = GrievanceAccessControl.get_accessible_categories(
-            self.user_no_perms
+            self.user_restricted_viewer, 'restricted_read'
         )
-        self.assertEqual(categories, TicketConfig.grievance_types)
+        self.assertIn('complaint', categories)
         
-        # Should return all flags when no processed config
-        flags = GrievanceAccessControl.get_accessible_flags(self.user_no_perms)
-        self.assertEqual(flags, TicketConfig.grievance_flags)
+        # Same user with higher requirement
+        categories = GrievanceAccessControl.get_accessible_categories(
+            self.user_restricted_viewer, 'read'
+        )
+        self.assertNotIn('complaint', categories)
     
-    def test_parent_visible_child_restricted_permissions(self):
-        """Test permission checking where parent is accessible but specific child is not"""
-        # Add test configuration for mixed parent-child permissions
-        additional_cfg = {
-            'grievance_types': [
-                {
-                    'name': 'parent_mixed',
-                    'priority': 'Medium',
-                    'permissions': ['127000'],  # View tickets - Limited user has this
-                    'children': [
-                        {
-                            'name': 'accessible_child'
-                            # No permissions - will inherit parent's
-                        },
-                        {
-                            'name': 'restricted_child',
-                            'priority': 'High',
-                            'permissions': ['127006']  # Resolve grievances - Limited user doesn't have this
-                        }
-                    ]
-                }
-            ]
+    def test_empty_permissions_means_no_restrictions(self):
+        """Test that categories/flags without permissions have no access restrictions"""
+        # simple_category has no permissions defined
+        self.assertIsNone(
+            GrievanceAccessControl.check_category_access(
+                self.user_no_rights, 'simple_category', 'read'
+            )
+        )
+        
+        # public flag has no permissions
+        self.assertIsNone(
+            GrievanceAccessControl.check_flag_access(
+                self.user_no_rights, 'public', 'read'
+            )
+        )
+    
+    def test_filter_ticket_queryset(self):
+        """Test filtering queryset based on user rights"""
+        
+        # Create test tickets
+        ticket1 = Ticket(
+            category='complaint',
+            title='Test Complaint',
+            code='TEST001'
+        )
+        ticket1.save(user=self.user_manager.user)
+        
+        ticket2 = Ticket(
+            category='simple_category',
+            title='Test Simple',
+            code='TEST002'
+        )
+        ticket2.save(user=self.user_manager.user)
+        
+        # User with no rights should only see unrestricted tickets
+        queryset = Ticket.objects.all()
+        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_no_rights)
+        
+        # Should only see simple_category ticket
+        self.assertIn(ticket2, filtered)
+        self.assertNotIn(ticket1, filtered)
+        
+        # User with restricted access should see both
+        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_restricted_viewer)
+        self.assertGreaterEqual(filtered.count(), 2)  # At least our 2 tickets
+        
+        # Clean up
+        ticket1.delete(user=self.user_manager.user)
+        ticket2.delete(user=self.user_manager.user)
+
+
+class GrievanceRightsManagerTest(TestCase):
+    """Test automatic rights generation functionality"""
+    
+    def test_get_next_available_id(self):
+        """Test the internal ID generation logic"""
+        # Test that the suffix pattern is maintained
+        used_ids = set()
+        
+        # Test read permission (suffix 0)
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+        self.assertEqual(next_id % 10, 0)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0)
+        
+        # Test create permission (suffix 1)
+        next_id = GrievanceRightsManager._get_next_available_id('create', used_ids)
+        self.assertEqual(next_id % 10, 1)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 1)
+        
+        # Test with some used IDs
+        used_ids = {127100, 127101, 127102}
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+        self.assertEqual(next_id, 127110)  # Next available with suffix 0
+    
+    def test_generate_automatic_rights_integration(self):
+        """Test the actual rights generation process"""
+        
+        # Create a mock app config with proper module
+        app_config = TicketConfig('grievance_social_protection', grievance_social_protection)
+        
+        # Set up test configuration
+        app_config.processed_categories = {
+            'test_category': {
+                'permissions': ['read', 'create', 'update']
+            }
+        }
+        app_config.processed_flags = {
+            'test_flag': {
+                'permissions': ['read']
+            }
         }
         
-        # Process the additional configuration
-        TicketConfig._TicketConfig__process_unified_categories(additional_cfg)
+        # Count permissions before
+        ct = ContentType.objects.get_for_model(Ticket)
+        perms_before = Permission.objects.filter(
+            content_type=ct,
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).count()
         
-        # Merge with existing configuration and reload
-        TicketConfig.grievance_types.extend(additional_cfg['grievance_types'])
-        TicketConfig.processed_categories.update(additional_cfg['processed_categories'])
+        # Generate rights
+        GrievanceRightsManager.generate_automatic_rights(app_config)
         
-        # Test parent access
-        self.assertTrue(
-            GrievanceAccessControl.check_category_permission(
-                self.user_limited_perms, 'parent_mixed'
-            )
-        )
+        # Check that permissions were created
+        perms_after = Permission.objects.filter(
+            content_type=ct,
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).count()
         
-        # Test accessible child (inherits parent permission)
-        self.assertTrue(
-            GrievanceAccessControl.check_category_permission(
-                self.user_limited_perms, 'parent_mixed|accessible_child'
-            )
-        )
+        # Should have created at least some permissions
+        self.assertGreaterEqual(perms_after, perms_before)
         
-        # Test restricted child (requires different permission)
-        self.assertFalse(
-            GrievanceAccessControl.check_category_permission(
-                self.user_limited_perms, 'parent_mixed|restricted_child'
-            )
-        )
+        # Check that generated_rights were populated
+        self.assertIn('generated_rights', app_config.processed_categories['test_category'])
+        self.assertIn('generated_rights', app_config.processed_flags['test_flag'])
         
-        # User with all permissions should access everything
-        self.assertTrue(
-            GrievanceAccessControl.check_category_permission(
-                self.user_with_perms, 'parent_mixed|restricted_child'
-            )
-        )
-        
-        # Test hierarchy retrieval
-        hierarchy = GrievanceAccessControl.get_category_hierarchy(
-            self.user_limited_perms
-        )
-        
-        # Find the parent_mixed category in hierarchy
-        parent_mixed = next((cat for cat in hierarchy if cat['name'] == 'parent_mixed'), None)
-        self.assertIsNotNone(parent_mixed)
-        
-        # Should have only one visible child
-        visible_children = parent_mixed.get('children', [])
-        self.assertEqual(len(visible_children), 1)
-        self.assertEqual(visible_children[0]['name'], 'accessible_child')
-    
+        # Clean up created permissions
+        Permission.objects.filter(
+            content_type=ct,
+            codename__endswith='_grievance',
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).delete()

--- a/grievance_social_protection/tests/test_access_control.py
+++ b/grievance_social_protection/tests/test_access_control.py
@@ -13,6 +13,7 @@ from grievance_social_protection.tests.test_helpers import (
 )
 import grievance_social_protection
 
+
 class GrievanceAccessControlTest(TestCase):
     """Test automatic rights generation and access control for grievance categories and flags"""
 

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -1,0 +1,213 @@
+from django.test import TestCase
+
+from grievance_social_protection.apps import TicketConfig
+
+
+class ConfigProcessingTest(TestCase):
+    """Test configuration processing for unified category and flag formats"""
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+    
+    def test_process_simple_string_categories(self):
+        """Test processing simple string category list"""
+        cfg = {
+            'grievance_types': ['complaint', 'feedback', 'appeal']
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        
+        # Check flat list maintained
+        self.assertEqual(cfg['grievance_types'], ['complaint', 'feedback', 'appeal'])
+        
+        # Check processed structure
+        processed = cfg['processed_categories']
+        self.assertEqual(len(processed), 3)
+        
+        # Check category details
+        self.assertIn('complaint', processed)
+        self.assertEqual(processed['complaint']['priority'], 'Medium')
+        self.assertEqual(processed['complaint']['permissions'], [])
+        self.assertEqual(processed['complaint']['parent'], None)
+    
+    def test_process_mixed_categories(self):
+        """Test processing mixed string and dict categories"""
+        cfg = {
+            'grievance_types': [
+                'simple',
+                {
+                    'name': 'complex',
+                    'priority': 'High',
+                    'permissions': ['127001', '127002'] 
+                },
+                {
+                    'name': 'detailed',
+                    'priority': 'Critical',
+                    'permissions': ['127003', '127004'],
+                    'default_flags': ['urgent']
+                }
+            ]
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        
+        # Check flat list
+        self.assertEqual(set(cfg['grievance_types']), {'simple', 'complex', 'detailed'})
+        
+        # Check processed details
+        processed = cfg['processed_categories']
+        
+        # Simple string
+        self.assertEqual(processed['simple']['permissions'], [])
+        
+        # List permissions
+        self.assertEqual(processed['complex']['priority'], 'High')
+        self.assertEqual(processed['complex']['permissions'], ['127001', '127002'])
+        
+        # Another list permissions format
+        self.assertEqual(processed['detailed']['priority'], 'Critical')
+        self.assertEqual(processed['detailed']['permissions'], ['127003', '127004'])
+        self.assertEqual(processed['detailed']['default_flags'], ['urgent'])
+    
+    def test_process_hierarchical_categories(self):
+        """Test processing hierarchical category structure"""
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'parent',
+                    'priority': 'High',
+                    'permissions': ['127001', '127002'],
+                    'default_flags': ['important'],
+                    'children': [
+                        {
+                            'name': 'child1',
+                            'permissions': ['127003']  # Override parent permissions
+                        },
+                        'child2',  # Simple string child
+                        {
+                            'name': 'child3',
+                            'priority': 'Critical',  # Override parent priority
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        
+        # Check flat list includes all levels
+        expected = {'parent', 'parent|child1', 'parent|child2', 'parent|child3'}
+        self.assertEqual(set(cfg['grievance_types']), expected)
+        
+        processed = cfg['processed_categories']
+        
+        # Check parent
+        self.assertEqual(processed['parent']['priority'], 'High')
+        self.assertEqual(processed['parent']['children'], {
+            'child1': 'parent|child1',
+            'child2': 'parent|child2',
+            'child3': 'parent|child3'
+        })
+        
+        # Check child inheritance
+        self.assertEqual(processed['parent|child1']['parent'], 'parent')
+        self.assertEqual(processed['parent|child1']['default_flags'], ['important'])
+        self.assertEqual(processed['parent|child1']['permissions'], ['127003'])
+
+        self.assertEqual(processed['parent|child3']['default_flags'], ['important'])  # Inherited
+        self.assertEqual(processed['parent|child3']['permissions'], ['127001', '127002'])  # Inherited
+        self.assertEqual(processed['parent|child3']['priority'], 'Critical')
+
+        # Check simple string child
+        self.assertEqual(processed['parent|child2']['priority'], 'High')  # Inherited
+        self.assertEqual(processed['parent|child2']['permissions'], ['127001', '127002'])  # Inherited from parent
+        self.assertEqual(processed['parent|child2']['default_flags'], ['important'])  # Inherited
+
+
+    def test_process_flags(self):
+        """Test processing flag configurations"""
+        cfg = {
+            'grievance_flags': [
+                'simple_flag',
+                {
+                    'name': 'complex_flag',
+                    'priority': 'High',
+                    'permissions': ['127004', '127005']
+                }
+            ]
+        }
+        
+        TicketConfig._TicketConfig__process_unified_flags(cfg)
+        
+        # Check flat list
+        self.assertEqual(cfg['grievance_flags'], ['simple_flag', 'complex_flag'])
+
+        processed = cfg['processed_flags']
+        
+        # Simple flag
+        self.assertEqual(processed['simple_flag']['permissions'], [])
+        
+        # List permissions - stored as-is
+        self.assertEqual(processed['complex_flag']['priority'], 'High')
+        self.assertEqual(processed['complex_flag']['permissions'], ['127004', '127005'])
+    
+    def test_category_resolution_times(self):
+        """Test processing categories with resolution times"""
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'urgent',
+                    'resolution_times': '1,0',  # 1 day
+                    'children': [
+                        {
+                            'name': 'very_urgent',
+                            'resolution_times': '0,12'  # 12 hours
+                        },
+                        {
+                            'name': 'less_urgent'
+                            # Inherits parent's 1,0 during processing
+                        }
+                    ]
+                },
+                'normal'  # No resolution time specified
+            ],
+            'resolution_times': '5,0'  # Global default
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        
+        processed = cfg['processed_categories']
+        
+        # Check resolution times are stored
+        self.assertEqual(processed['urgent']['resolution_times'], '1,0')
+        self.assertEqual(processed['urgent|very_urgent']['resolution_times'], '0,12')
+        # Child without resolution_times inherits from parent during processing
+        self.assertEqual(processed['urgent|less_urgent']['resolution_times'], '1,0')
+        # Simple category should not have resolution_times
+        self.assertIsNone(processed['normal']['resolution_times'])
+    
+    def test_resolution_times_with_mixed_configuration(self):
+        """Test resolution times with both category-specific and default_resolution"""
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'priority_cat',
+                    'resolution_times': '2,0'  # Category-specific
+                },
+                'legacy_cat'
+            ],
+            'default_resolution': {
+                'priority_cat': '3,0',  # Should be overridden by category-specific
+                'legacy_cat': '4,0'     # Should be used
+            },
+            'resolution_times': '5,0'
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        TicketConfig._TicketConfig__validate_grievance_default_resolution_time(cfg)
+        
+        # Check unified resolution times mapping
+        unified = cfg.get('unified_resolution_times', {})
+        self.assertEqual(unified['priority_cat'], '2,0')  # Category-specific wins
+        self.assertEqual(unified['legacy_cat'], '4,0')    # From default_resolution

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -5,32 +5,32 @@ from grievance_social_protection.apps import TicketConfig
 
 class ConfigProcessingTest(TestCase):
     """Test configuration processing for unified category and flag formats"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-    
+
     def test_process_simple_string_categories(self):
         """Test processing simple string category list"""
         cfg = {
             'grievance_types': ['complaint', 'feedback', 'appeal']
         }
-        
+
         TicketConfig._TicketConfig__process_unified_categories(cfg)
-        
+
         # Check flat list maintained - includes 'uncategorized' added by default
         self.assertEqual(cfg['grievance_types'], ['uncategorized', 'complaint', 'feedback', 'appeal'])
-        
-        # Check processed structure - includes 'uncategorized' 
+
+        # Check processed structure - includes 'uncategorized'
         processed = cfg['processed_categories']
         self.assertEqual(len(processed), 4)
-        
+
         # Check category details
         self.assertIn('complaint', processed)
         self.assertEqual(processed['complaint']['priority'], 'Medium')
         self.assertEqual(processed['complaint']['permissions'], [])
         self.assertEqual(processed['complaint']['parent'], None)
-    
+
     def test_process_mixed_categories(self):
         """Test processing mixed string and dict categories"""
         cfg = {
@@ -69,7 +69,7 @@ class ConfigProcessingTest(TestCase):
         self.assertEqual(processed['detailed']['priority'], 'Critical')
         self.assertEqual(processed['detailed']['permissions'], ['update', 'delete'])
         self.assertEqual(processed['detailed']['default_flags'], ['urgent'])
-    
+
     def test_process_hierarchical_categories(self):
         """Test processing hierarchical category structure"""
         cfg = {
@@ -124,7 +124,6 @@ class ConfigProcessingTest(TestCase):
         self.assertEqual(processed['parent|child2']['permissions'], ['read', 'create'])  # Inherited from parent
         self.assertEqual(processed['parent|child2']['default_flags'], ['important'])  # Inherited
 
-
     def test_process_flags(self):
         """Test processing flag configurations"""
         cfg = {
@@ -151,7 +150,7 @@ class ConfigProcessingTest(TestCase):
         # List permissions - stored as-is
         self.assertEqual(processed['complex_flag']['priority'], 'High')
         self.assertEqual(processed['complex_flag']['permissions'], ['read', 'update'])
-    
+
     def test_category_resolution_times(self):
         """Test processing categories with resolution times"""
         cfg = {
@@ -174,11 +173,11 @@ class ConfigProcessingTest(TestCase):
             ],
             'resolution_times': '5,0'  # Global default
         }
-        
+
         TicketConfig._TicketConfig__process_unified_categories(cfg)
-        
+
         processed = cfg['processed_categories']
-        
+
         # Check resolution times are stored
         self.assertEqual(processed['urgent']['resolution_times'], '1,0')
         self.assertEqual(processed['urgent|very_urgent']['resolution_times'], '0,12')
@@ -186,7 +185,7 @@ class ConfigProcessingTest(TestCase):
         self.assertEqual(processed['urgent|less_urgent']['resolution_times'], '1,0')
         # Simple category should not have resolution_times
         self.assertIsNone(processed['normal']['resolution_times'])
-    
+
     def test_resolution_times_with_mixed_configuration(self):
         """Test resolution times with both category-specific and default_resolution"""
         cfg = {
@@ -203,10 +202,10 @@ class ConfigProcessingTest(TestCase):
             },
             'resolution_times': '5,0'
         }
-        
+
         TicketConfig._TicketConfig__process_unified_categories(cfg)
         TicketConfig._TicketConfig__validate_grievance_default_resolution_time(cfg)
-        
+
         # Check unified resolution times mapping
         unified = cfg.get('unified_resolution_times', {})
         self.assertEqual(unified['priority_cat'], '2,0')  # Category-specific wins

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -18,12 +18,12 @@ class ConfigProcessingTest(TestCase):
         
         TicketConfig._TicketConfig__process_unified_categories(cfg)
         
-        # Check flat list maintained
-        self.assertEqual(cfg['grievance_types'], ['complaint', 'feedback', 'appeal'])
+        # Check flat list maintained - includes 'uncategorized' added by default
+        self.assertEqual(cfg['grievance_types'], ['uncategorized', 'complaint', 'feedback', 'appeal'])
         
-        # Check processed structure
+        # Check processed structure - includes 'uncategorized' 
         processed = cfg['processed_categories']
-        self.assertEqual(len(processed), 3)
+        self.assertEqual(len(processed), 4)
         
         # Check category details
         self.assertIn('complaint', processed)
@@ -52,8 +52,8 @@ class ConfigProcessingTest(TestCase):
         
         TicketConfig._TicketConfig__process_unified_categories(cfg)
         
-        # Check flat list
-        self.assertEqual(set(cfg['grievance_types']), {'simple', 'complex', 'detailed'})
+        # Check flat list - includes 'uncategorized' added by default
+        self.assertEqual(set(cfg['grievance_types']), {'uncategorized', 'simple', 'complex', 'detailed'})
         
         # Check processed details
         processed = cfg['processed_categories']
@@ -96,8 +96,8 @@ class ConfigProcessingTest(TestCase):
         
         TicketConfig._TicketConfig__process_unified_categories(cfg)
         
-        # Check flat list includes all levels
-        expected = {'parent', 'parent|child1', 'parent|child2', 'parent|child3'}
+        # Check flat list includes all levels - plus 'uncategorized' added by default
+        expected = {'uncategorized', 'parent', 'parent|child1', 'parent|child2', 'parent|child3'}
         self.assertEqual(set(cfg['grievance_types']), expected)
         
         processed = cfg['processed_categories']

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -39,35 +39,35 @@ class ConfigProcessingTest(TestCase):
                 {
                     'name': 'complex',
                     'priority': 'High',
-                    'permissions': ['127001', '127002'] 
+                    'permissions': ['read', 'create']
                 },
                 {
                     'name': 'detailed',
                     'priority': 'Critical',
-                    'permissions': ['127003', '127004'],
+                    'permissions': ['update', 'delete'],
                     'default_flags': ['urgent']
                 }
             ]
         }
-        
+
         TicketConfig._TicketConfig__process_unified_categories(cfg)
-        
+
         # Check flat list - includes 'uncategorized' added by default
         self.assertEqual(set(cfg['grievance_types']), {'uncategorized', 'simple', 'complex', 'detailed'})
-        
+
         # Check processed details
         processed = cfg['processed_categories']
-        
+
         # Simple string
         self.assertEqual(processed['simple']['permissions'], [])
-        
+
         # List permissions
         self.assertEqual(processed['complex']['priority'], 'High')
-        self.assertEqual(processed['complex']['permissions'], ['127001', '127002'])
-        
+        self.assertEqual(processed['complex']['permissions'], ['read', 'create'])
+
         # Another list permissions format
         self.assertEqual(processed['detailed']['priority'], 'Critical')
-        self.assertEqual(processed['detailed']['permissions'], ['127003', '127004'])
+        self.assertEqual(processed['detailed']['permissions'], ['update', 'delete'])
         self.assertEqual(processed['detailed']['default_flags'], ['urgent'])
     
     def test_process_hierarchical_categories(self):
@@ -77,12 +77,12 @@ class ConfigProcessingTest(TestCase):
                 {
                     'name': 'parent',
                     'priority': 'High',
-                    'permissions': ['127001', '127002'],
+                    'permissions': ['read', 'create'],
                     'default_flags': ['important'],
                     'children': [
                         {
                             'name': 'child1',
-                            'permissions': ['127003']  # Override parent permissions
+                            'permissions': ['update']  # Override parent permissions
                         },
                         'child2',  # Simple string child
                         {
@@ -93,15 +93,15 @@ class ConfigProcessingTest(TestCase):
                 }
             ]
         }
-        
+
         TicketConfig._TicketConfig__process_unified_categories(cfg)
-        
+
         # Check flat list includes all levels - plus 'uncategorized' added by default
         expected = {'uncategorized', 'parent', 'parent|child1', 'parent|child2', 'parent|child3'}
         self.assertEqual(set(cfg['grievance_types']), expected)
-        
+
         processed = cfg['processed_categories']
-        
+
         # Check parent
         self.assertEqual(processed['parent']['priority'], 'High')
         self.assertEqual(processed['parent']['children'], {
@@ -109,19 +109,19 @@ class ConfigProcessingTest(TestCase):
             'child2': 'parent|child2',
             'child3': 'parent|child3'
         })
-        
+
         # Check child inheritance
         self.assertEqual(processed['parent|child1']['parent'], 'parent')
         self.assertEqual(processed['parent|child1']['default_flags'], ['important'])
-        self.assertEqual(processed['parent|child1']['permissions'], ['127003'])
+        self.assertEqual(processed['parent|child1']['permissions'], ['update'])
 
         self.assertEqual(processed['parent|child3']['default_flags'], ['important'])  # Inherited
-        self.assertEqual(processed['parent|child3']['permissions'], ['127001', '127002'])  # Inherited
+        self.assertEqual(processed['parent|child3']['permissions'], ['read', 'create'])  # Inherited
         self.assertEqual(processed['parent|child3']['priority'], 'Critical')
 
         # Check simple string child
         self.assertEqual(processed['parent|child2']['priority'], 'High')  # Inherited
-        self.assertEqual(processed['parent|child2']['permissions'], ['127001', '127002'])  # Inherited from parent
+        self.assertEqual(processed['parent|child2']['permissions'], ['read', 'create'])  # Inherited from parent
         self.assertEqual(processed['parent|child2']['default_flags'], ['important'])  # Inherited
 
 
@@ -133,24 +133,24 @@ class ConfigProcessingTest(TestCase):
                 {
                     'name': 'complex_flag',
                     'priority': 'High',
-                    'permissions': ['127004', '127005']
+                    'permissions': ['read', 'update']
                 }
             ]
         }
-        
+
         TicketConfig._TicketConfig__process_unified_flags(cfg)
-        
+
         # Check flat list
         self.assertEqual(cfg['grievance_flags'], ['simple_flag', 'complex_flag'])
 
         processed = cfg['processed_flags']
-        
+
         # Simple flag
         self.assertEqual(processed['simple_flag']['permissions'], [])
-        
+
         # List permissions - stored as-is
         self.assertEqual(processed['complex_flag']['priority'], 'High')
-        self.assertEqual(processed['complex_flag']['permissions'], ['127004', '127005'])
+        self.assertEqual(processed['complex_flag']['permissions'], ['read', 'update'])
     
     def test_category_resolution_times(self):
         """Test processing categories with resolution times"""

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -97,7 +97,7 @@ class ConfigProcessingTest(TestCase):
         TicketConfig._TicketConfig__process_unified_categories(cfg)
 
         # Check flat list includes all levels - plus 'uncategorized' added by default
-        expected = {'uncategorized', 'parent', 'parent|child1', 'parent|child2', 'parent|child3'}
+        expected = {'uncategorized', 'parent', 'parent > child1', 'parent > child2', 'parent > child3'}
         self.assertEqual(set(cfg['grievance_types']), expected)
 
         processed = cfg['processed_categories']
@@ -105,24 +105,24 @@ class ConfigProcessingTest(TestCase):
         # Check parent
         self.assertEqual(processed['parent']['priority'], 'High')
         self.assertEqual(processed['parent']['children'], {
-            'child1': 'parent|child1',
-            'child2': 'parent|child2',
-            'child3': 'parent|child3'
+            'child1': 'parent > child1',
+            'child2': 'parent > child2',
+            'child3': 'parent > child3'
         })
 
         # Check child inheritance
-        self.assertEqual(processed['parent|child1']['parent'], 'parent')
-        self.assertEqual(processed['parent|child1']['default_flags'], ['important'])
-        self.assertEqual(processed['parent|child1']['permissions'], ['update'])
+        self.assertEqual(processed['parent > child1']['parent'], 'parent')
+        self.assertEqual(processed['parent > child1']['default_flags'], ['important'])
+        self.assertEqual(processed['parent > child1']['permissions'], ['update'])
 
-        self.assertEqual(processed['parent|child3']['default_flags'], ['important'])  # Inherited
-        self.assertEqual(processed['parent|child3']['permissions'], ['read', 'create'])  # Inherited
-        self.assertEqual(processed['parent|child3']['priority'], 'Critical')
+        self.assertEqual(processed['parent > child3']['default_flags'], ['important'])  # Inherited
+        self.assertEqual(processed['parent > child3']['permissions'], ['read', 'create'])  # Inherited
+        self.assertEqual(processed['parent > child3']['priority'], 'Critical')
 
         # Check simple string child
-        self.assertEqual(processed['parent|child2']['priority'], 'High')  # Inherited
-        self.assertEqual(processed['parent|child2']['permissions'], ['read', 'create'])  # Inherited from parent
-        self.assertEqual(processed['parent|child2']['default_flags'], ['important'])  # Inherited
+        self.assertEqual(processed['parent > child2']['priority'], 'High')  # Inherited
+        self.assertEqual(processed['parent > child2']['permissions'], ['read', 'create'])  # Inherited from parent
+        self.assertEqual(processed['parent > child2']['default_flags'], ['important'])  # Inherited
 
     def test_process_flags(self):
         """Test processing flag configurations"""
@@ -180,9 +180,9 @@ class ConfigProcessingTest(TestCase):
 
         # Check resolution times are stored
         self.assertEqual(processed['urgent']['resolution_times'], '1,0')
-        self.assertEqual(processed['urgent|very_urgent']['resolution_times'], '0,12')
+        self.assertEqual(processed['urgent > very_urgent']['resolution_times'], '0,12')
         # Child without resolution_times inherits from parent during processing
-        self.assertEqual(processed['urgent|less_urgent']['resolution_times'], '1,0')
+        self.assertEqual(processed['urgent > less_urgent']['resolution_times'], '1,0')
         # Simple category should not have resolution_times
         self.assertIsNone(processed['normal']['resolution_times'])
 

--- a/grievance_social_protection/tests/test_gql_ticket_comment_create.py
+++ b/grievance_social_protection/tests/test_gql_ticket_comment_create.py
@@ -1,5 +1,4 @@
 from django.apps import apps
-from django.test import TestCase
 
 from graphene import Schema
 from graphene.test import Client
@@ -15,8 +14,8 @@ from grievance_social_protection.tests.test_helpers import create_ticket, create
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 from uuid import uuid4
 
-class GQLTicketCommentCreateTestCase(openIMISGraphQLTestCase):
 
+class GQLTicketCommentCreateTestCase(openIMISGraphQLTestCase):
 
     user = None
 

--- a/grievance_social_protection/tests/test_gql_ticket_create.py
+++ b/grievance_social_protection/tests/test_gql_ticket_create.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
@@ -10,7 +9,6 @@ from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, Base
 
 
 class GQLTicketCreateTestCase(openIMISGraphQLTestCase):
-
 
     user = None
 

--- a/grievance_social_protection/tests/test_gql_ticket_reopen.py
+++ b/grievance_social_protection/tests/test_gql_ticket_reopen.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
@@ -16,8 +15,8 @@ from grievance_social_protection.tests.test_helpers import (
 
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 
-class GQLTicketReopenTestCase(openIMISGraphQLTestCase):
 
+class GQLTicketReopenTestCase(openIMISGraphQLTestCase):
 
     user = None
     status = None

--- a/grievance_social_protection/tests/test_gql_ticket_resolve_by_comment.py
+++ b/grievance_social_protection/tests/test_gql_ticket_resolve_by_comment.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
@@ -17,7 +16,6 @@ from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, Base
 
 
 class GQLTicketResolveByCommentTestCase(openIMISGraphQLTestCase):
-
 
     user = None
 

--- a/grievance_social_protection/tests/test_gql_ticket_update.py
+++ b/grievance_social_protection/tests/test_gql_ticket_update.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
@@ -10,7 +9,6 @@ from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, Base
 
 
 class GQLTicketUpdateTestCase(openIMISGraphQLTestCase):
-
 
     user = None
 

--- a/grievance_social_protection/tests/test_helpers.py
+++ b/grievance_social_protection/tests/test_helpers.py
@@ -66,10 +66,14 @@ def assign_rights_to_user(user, right_ids, role_name=None):
         defaults={'is_system': 0, 'is_blocked': False, 'audit_user_id': -1}
     )
     for right_id in right_ids:
-        RoleRight.objects.create(
-            role=role, right_id=int(right_id), audit_user_id=-1
+        RoleRight.objects.get_or_create(
+            role=role, right_id=int(right_id),
+            defaults={'audit_user_id': -1}
         )
-    UserRole.objects.create(user=user.i_user, role=role, audit_user_id=-1)
+    UserRole.objects.get_or_create(
+        user=user.i_user, role=role,
+        defaults={'audit_user_id': -1}
+    )
 
 
 def get_rights(config_attr, name):

--- a/grievance_social_protection/tests/test_helpers.py
+++ b/grievance_social_protection/tests/test_helpers.py
@@ -42,16 +42,39 @@ def create_comment_for_existing_ticket(user, ticket, resolved=False):
     return comment
 
 
+def save_grievance_config():
+    """Snapshot TicketConfig class-level state so it can be restored later."""
+    return {
+        'processed_categories': dict(TicketConfig.processed_categories),
+        'processed_flags': dict(TicketConfig.processed_flags),
+        'grievance_types': list(TicketConfig.grievance_types),
+        'grievance_flags': list(TicketConfig.grievance_flags),
+        'generated_rights': dict(TicketConfig.generated_rights),
+        'unified_resolution_times': dict(TicketConfig.unified_resolution_times),
+    }
+
+
+def restore_grievance_config(snapshot):
+    """Restore TicketConfig class-level state from a snapshot."""
+    for attr, value in snapshot.items():
+        setattr(TicketConfig, attr, value)
+
+
 def setup_grievance_config(cfg):
     """Process a grievance config dict and generate rights on TicketConfig.
 
     Handles the standard sequence: process categories, process flags,
     load config, and generate automatic rights.
+
+    Returns:
+        dict: Snapshot of previous state (pass to restore_grievance_config).
     """
+    snapshot = save_grievance_config()
     TicketConfig._TicketConfig__process_unified_categories(cfg)
     TicketConfig._TicketConfig__process_unified_flags(cfg)
     TicketConfig._TicketConfig__load_config(cfg)
     GrievanceRightsManager.generate_automatic_rights(TicketConfig)
+    return snapshot
 
 
 def assign_rights_to_user(user, right_ids, role_name=None):

--- a/grievance_social_protection/tests/test_helpers.py
+++ b/grievance_social_protection/tests/test_helpers.py
@@ -1,7 +1,10 @@
+from core.models import Role, RoleRight, UserRole
+from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import (
     Comment,
     Ticket
 )
+from grievance_social_protection.rights import GrievanceRightsManager
 from grievance_social_protection.tests.data import service_add_ticket_payload
 
 
@@ -22,3 +25,56 @@ def create_comment_for_existing_ticket(user, ticket, resolved=False):
         ticket.status = 'CLOSED'
         ticket.save(user=user)
     return comment
+
+
+def setup_grievance_config(cfg):
+    """Process a grievance config dict and generate rights on TicketConfig.
+
+    Handles the standard sequence: process categories, process flags,
+    load config, and generate automatic rights.
+    """
+    TicketConfig._TicketConfig__process_unified_categories(cfg)
+    TicketConfig._TicketConfig__process_unified_flags(cfg)
+    TicketConfig._TicketConfig__load_config(cfg)
+    GrievanceRightsManager.generate_automatic_rights(TicketConfig)
+
+
+def assign_rights_to_user(user, right_ids, role_name=None):
+    """Create a role with given right IDs and assign it to the user.
+
+    Uses get_or_create for the Role to be safe with --keepdb.
+    """
+    if not (hasattr(user, 'i_user') and user.i_user) or not right_ids:
+        return
+    role, _ = Role.objects.get_or_create(
+        name=role_name or f'TestRole_{getattr(user, "username", "unknown")}',
+        defaults={'is_system': 0, 'is_blocked': False, 'audit_user_id': -1}
+    )
+    for right_id in right_ids:
+        RoleRight.objects.create(
+            role=role, right_id=int(right_id), audit_user_id=-1
+        )
+    UserRole.objects.create(user=user.i_user, role=role, audit_user_id=-1)
+
+
+def get_rights(config_attr, name):
+    """Get generated_rights dict for a category or flag from TicketConfig.
+
+    Args:
+        config_attr: 'processed_categories' or 'processed_flags'
+        name: Category or flag name
+
+    Returns:
+        dict of {access_type: right_id}, or empty dict if not found
+    """
+    return getattr(TicketConfig, config_attr, {}).get(name, {}).get('generated_rights', {})
+
+
+def collect_all_rights():
+    """Collect all generated right IDs across categories and flags."""
+    right_ids = set()
+    for info in TicketConfig.processed_categories.values():
+        right_ids.update(info.get('generated_rights', {}).values())
+    for info in TicketConfig.processed_flags.values():
+        right_ids.update(info.get('generated_rights', {}).values())
+    return right_ids

--- a/grievance_social_protection/tests/test_model_security.py
+++ b/grievance_social_protection/tests/test_model_security.py
@@ -2,8 +2,11 @@
 Test that security filtering is properly implemented at the model level.
 This ensures security is enforced consistently across all endpoints (GraphQL, FHIR, etc.)
 """
+from unittest.mock import Mock
+
 from django.test import TestCase
 from django.conf import settings
+from graphql import ResolveInfo
 
 from core.test_helpers import create_test_interactive_user
 from grievance_social_protection.models import Ticket, Comment
@@ -216,9 +219,6 @@ class ModelSecurityTest(TestCase):
 
     def test_graphql_info_object_handling(self):
         """Test that GraphQL ResolveInfo objects are handled correctly"""
-        from graphql import ResolveInfo
-        from unittest.mock import Mock
-
         # Create a mock ResolveInfo with user
         mock_info = Mock(spec=ResolveInfo)
         mock_info.context = Mock()

--- a/grievance_social_protection/tests/test_model_security.py
+++ b/grievance_social_protection/tests/test_model_security.py
@@ -4,28 +4,28 @@ This ensures security is enforced consistently across all endpoints (GraphQL, FH
 """
 from django.test import TestCase
 from django.conf import settings
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 
 from core.test_helpers import create_test_interactive_user
 from grievance_social_protection.models import Ticket, Comment
-from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, collect_all_rights,
+)
 
 
 class ModelSecurityTest(TestCase):
     """Test security filtering at the model level"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._setup_test_config()
         cls._create_test_users()
         cls._create_test_tickets()
-    
+
     @classmethod
     def _setup_test_config(cls):
         """Set up test configuration"""
-        config = {
+        cfg = {
             'grievance_types': [
                 'public_category',
                 {
@@ -35,7 +35,7 @@ class ModelSecurityTest(TestCase):
                 },
                 {
                     'name': 'highly_restricted',
-                    'visible_fields': ['id', 'status'],  # Very limited visibility
+                    'visible_fields': ['id', 'status'],
                     'permissions': ['restricted_read', 'read']
                 }
             ],
@@ -47,133 +47,26 @@ class ModelSecurityTest(TestCase):
                 }
             ]
         }
-        
-        # Process configuration
-        TicketConfig._TicketConfig__process_unified_categories(config)
-        TicketConfig._TicketConfig__process_unified_flags(config)
-        TicketConfig._TicketConfig__load_config(config)
-        
-        # Create permissions in test database
-        try:
-            ct = ContentType.objects.get_for_model(Ticket)
-            # Create test permissions with specific IDs
-            Permission.objects.get_or_create(
-                id=127200,
-                defaults={
-                    'codename': 'grievance_restricted_category_restricted_read',
-                    'name': 'Can restricted read restricted_category tickets',
-                    'content_type': ct
-                }
-            )
-            Permission.objects.get_or_create(
-                id=127201,
-                defaults={
-                    'codename': 'grievance_restricted_category_read',
-                    'name': 'Can read restricted_category tickets',
-                    'content_type': ct
-                }
-            )
-            Permission.objects.get_or_create(
-                id=127202,
-                defaults={
-                    'codename': 'grievance_restricted_category_create',
-                    'name': 'Can create restricted_category tickets',
-                    'content_type': ct
-                }
-            )
-            Permission.objects.get_or_create(
-                id=127421,
-                defaults={
-                    'codename': 'grievance_flag_confidential_read',
-                    'name': 'Can read confidential flagged tickets',
-                    'content_type': ct
-                }
-            )
-            Permission.objects.get_or_create(
-                id=127422,
-                defaults={
-                    'codename': 'grievance_flag_confidential_create',
-                    'name': 'Can create confidential flagged tickets',
-                    'content_type': ct
-                }
-            )
-            
-            # Update the processed config with generated rights
-            TicketConfig.processed_categories['restricted_category']['generated_rights'] = {
-                'restricted_read': 127200,
-                'read': 127201,
-                'create': 127202
-            }
-            TicketConfig.processed_flags['confidential']['generated_rights'] = {
-                'read': 127421,
-                'create': 127422
-            }
-        except Exception as e:
-            cls.stdout.write(f"Warning: Could not create test permissions: {e}")
-    
+        setup_grievance_config(cfg)
+
     @classmethod
     def _create_test_users(cls):
         """Create test users with different permission levels"""
-        from core.models import Role, RoleRight, UserRole
-        from core.utils import TimeUtils
-        
-        # Admin with all permissions - use admin role
-        cls.admin_user = create_test_interactive_user(username='test_admin', roles=[7])  # IMIS Administrator
-        
-        # Create custom role with all grievance permissions
-        admin_role = Role.objects.create(
-            name="Test Grievance Admin",
-            is_blocked=False,
-            is_system=False,
-            audit_user_id=-1,
-        )
-        
-        # Add base permissions
+        # Admin with all permissions
+        cls.admin_user = create_test_interactive_user(username='test_admin', roles=[7])
         base_perms = [127000, 127001, 127002, 127003, 127004, 127005, 127006]
-        # Add test-specific permissions
-        test_perms = [127200, 127201, 127202, 127421, 127422]
-        
-        for perm_id in base_perms + test_perms:
-            try:
-                RoleRight.objects.create(
-                    role=admin_role,
-                    right_id=perm_id,
-                    audit_user_id=-1,
-                    validity_from=TimeUtils.now(),
-                )
-            except Exception:
-                pass
-        
-        # Assign the custom role to admin user
-        UserRole.objects.create(
-            user=cls.admin_user.i_user,
-            role=admin_role,
-            audit_user_id=-1
-        )
-        
-        # Limited user with minimal permissions
-        limited_role = Role.objects.create(
-            name="Test Limited User",
-            is_blocked=False,
-            is_system=False,
-            audit_user_id=-1,
-        )
-        
-        # Only add base query permission
-        RoleRight.objects.create(
-            role=limited_role,
-            right_id=127000,
-            audit_user_id=-1,
-            validity_from=TimeUtils.now(),
-        )
-        
-        cls.limited_user = create_test_interactive_user(username='test_limited', roles=[limited_role.id])
-    
+        all_right_ids = base_perms + list(collect_all_rights())
+        assign_rights_to_user(cls.admin_user, all_right_ids, 'MSAdminRole')
+
+        # Limited user with only base query permission
+        cls.limited_user = create_test_interactive_user(username='test_limited', roles=[1])
+        assign_rights_to_user(cls.limited_user, [127000], 'MSLimitedRole')
+
     @classmethod
     def _create_test_tickets(cls):
         """Create test tickets"""
         cls.tickets = {}
-        
+
         # Public ticket - should be visible to all
         ticket = Ticket(
             title='Public ticket',
@@ -183,7 +76,7 @@ class ModelSecurityTest(TestCase):
         )
         ticket.save(user=cls.admin_user)
         cls.tickets['public'] = ticket
-        
+
         # Create comment on public ticket
         comment = Comment(
             ticket=ticket,
@@ -192,7 +85,7 @@ class ModelSecurityTest(TestCase):
         )
         comment.save(user=cls.admin_user)
         cls.public_comment = comment
-        
+
         # Restricted category ticket - should only be visible to admin
         ticket = Ticket(
             title='Restricted ticket',
@@ -202,7 +95,7 @@ class ModelSecurityTest(TestCase):
         )
         ticket.save(user=cls.admin_user)
         cls.tickets['restricted'] = ticket
-        
+
         # Create comment on restricted ticket
         comment = Comment(
             ticket=ticket,
@@ -211,7 +104,7 @@ class ModelSecurityTest(TestCase):
         )
         comment.save(user=cls.admin_user)
         cls.restricted_comment = comment
-        
+
         # Public category with confidential flag - should only be visible to admin
         ticket = Ticket(
             title='Confidential ticket',
@@ -221,28 +114,25 @@ class ModelSecurityTest(TestCase):
         )
         ticket.save(user=cls.admin_user)
         cls.tickets['confidential'] = ticket
-    
+
     @classmethod
     def tearDownClass(cls):
         """Clean up test data"""
-        # Delete tickets and comments
         Comment.objects.filter(ticket__in=cls.tickets.values()).delete()
         Ticket.objects.filter(id__in=[t.id for t in cls.tickets.values()]).delete()
         super().tearDownClass()
-    
+
     def test_ticket_security_with_row_security_enabled(self):
         """Test ticket filtering with ROW_SECURITY enabled"""
-        # Save original setting
         original_setting = getattr(settings, 'ROW_SECURITY', True)
         settings.ROW_SECURITY = True
-        
+
         try:
             # Test admin user
-            # Only test our tickets to avoid interference from other tests
             test_ticket_ids = [t.id for t in self.tickets.values()]
             queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, self.admin_user)
-            
+
             # Admin should see all 3 test tickets
             self.assertEqual(filtered.count(), 3)
             for name, ticket in self.tickets.items():
@@ -250,11 +140,11 @@ class ModelSecurityTest(TestCase):
                     filtered.filter(id=ticket.id).exists(),
                     f"Admin should see {name} ticket"
                 )
-            
+
             # Test limited user
             queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, self.limited_user)
-            
+
             # Limited user should only see public ticket
             self.assertEqual(filtered.count(), 1)
             self.assertTrue(
@@ -270,39 +160,34 @@ class ModelSecurityTest(TestCase):
                 "Limited user should not see confidential ticket"
             )
         finally:
-            # Restore original setting
             settings.ROW_SECURITY = original_setting
-    
+
     def test_ticket_security_with_row_security_disabled(self):
         """Test ticket filtering with ROW_SECURITY disabled"""
-        # Save original setting
         original_setting = getattr(settings, 'ROW_SECURITY', True)
         settings.ROW_SECURITY = False
-        
+
         try:
             # With ROW_SECURITY disabled, all users should see all tickets
-            # Filter to only our test tickets to avoid interference from other tests
             our_ticket_ids = [t.id for t in self.tickets.values()]
             queryset = Ticket.objects.filter(id__in=our_ticket_ids)
             filtered = Ticket.get_queryset(queryset, self.limited_user)
-            
+
             # Should see all tickets when security is disabled
             self.assertEqual(filtered.count(), 3)
         finally:
-            # Restore original setting
             settings.ROW_SECURITY = original_setting
-    
+
     def test_comment_security_inherits_from_ticket(self):
         """Test that comment security inherits from parent ticket"""
-        # Save original setting
         original_setting = getattr(settings, 'ROW_SECURITY', True)
         settings.ROW_SECURITY = True
-        
+
         try:
             # Test admin user
             queryset = Comment.objects.all()
             filtered = Comment.get_queryset(queryset, self.admin_user)
-            
+
             # Admin should see all comments
             self.assertTrue(
                 filtered.filter(id=self.public_comment.id).exists(),
@@ -312,11 +197,11 @@ class ModelSecurityTest(TestCase):
                 filtered.filter(id=self.restricted_comment.id).exists(),
                 "Admin should see restricted comment"
             )
-            
+
             # Test limited user
             queryset = Comment.objects.all()
             filtered = Comment.get_queryset(queryset, self.limited_user)
-            
+
             # Limited user should only see comment on public ticket
             self.assertTrue(
                 filtered.filter(id=self.public_comment.id).exists(),
@@ -327,29 +212,27 @@ class ModelSecurityTest(TestCase):
                 "Limited user should not see restricted comment"
             )
         finally:
-            # Restore original setting
             settings.ROW_SECURITY = original_setting
-    
+
     def test_graphql_info_object_handling(self):
         """Test that GraphQL ResolveInfo objects are handled correctly"""
         from graphql import ResolveInfo
         from unittest.mock import Mock
-        
+
         # Create a mock ResolveInfo with user
         mock_info = Mock(spec=ResolveInfo)
         mock_info.context = Mock()
         mock_info.context.user = self.limited_user
-        
-        # Save original setting
+
         original_setting = getattr(settings, 'ROW_SECURITY', True)
         settings.ROW_SECURITY = True
-        
+
         try:
             # Test that ResolveInfo is properly handled
             test_ticket_ids = [t.id for t in self.tickets.values()]
             queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, mock_info)
-            
+
             # Should extract user from ResolveInfo and apply filtering
             self.assertEqual(filtered.count(), 1)
             self.assertTrue(

--- a/grievance_social_protection/tests/test_model_security.py
+++ b/grievance_social_protection/tests/test_model_security.py
@@ -1,0 +1,357 @@
+"""
+Test that security filtering is properly implemented at the model level.
+This ensures security is enforced consistently across all endpoints (GraphQL, FHIR, etc.)
+"""
+from django.test import TestCase
+from django.conf import settings
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+from core.test_helpers import create_test_interactive_user
+from grievance_social_protection.models import Ticket, Comment
+from grievance_social_protection.apps import TicketConfig
+
+
+class ModelSecurityTest(TestCase):
+    """Test security filtering at the model level"""
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_test_config()
+        cls._create_test_users()
+        cls._create_test_tickets()
+    
+    @classmethod
+    def _setup_test_config(cls):
+        """Set up test configuration"""
+        config = {
+            'grievance_types': [
+                'public_category',
+                {
+                    'name': 'restricted_category',
+                    'permissions': ['restricted_read', 'read', 'create'],
+                    'visible_fields': ['id', 'status', 'priority', 'date_created']
+                },
+                {
+                    'name': 'highly_restricted',
+                    'visible_fields': ['id', 'status'],  # Very limited visibility
+                    'permissions': ['restricted_read', 'read']
+                }
+            ],
+            'grievance_flags': [
+                'public',
+                {
+                    'name': 'confidential',
+                    'permissions': ['read', 'create']
+                }
+            ]
+        }
+        
+        # Process configuration
+        TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__process_unified_flags(config)
+        TicketConfig._TicketConfig__load_config(config)
+        
+        # Create permissions in test database
+        try:
+            ct = ContentType.objects.get_for_model(Ticket)
+            # Create test permissions with specific IDs
+            Permission.objects.get_or_create(
+                id=127200,
+                defaults={
+                    'codename': 'grievance_restricted_category_restricted_read',
+                    'name': 'Can restricted read restricted_category tickets',
+                    'content_type': ct
+                }
+            )
+            Permission.objects.get_or_create(
+                id=127201,
+                defaults={
+                    'codename': 'grievance_restricted_category_read',
+                    'name': 'Can read restricted_category tickets',
+                    'content_type': ct
+                }
+            )
+            Permission.objects.get_or_create(
+                id=127202,
+                defaults={
+                    'codename': 'grievance_restricted_category_create',
+                    'name': 'Can create restricted_category tickets',
+                    'content_type': ct
+                }
+            )
+            Permission.objects.get_or_create(
+                id=127421,
+                defaults={
+                    'codename': 'grievance_flag_confidential_read',
+                    'name': 'Can read confidential flagged tickets',
+                    'content_type': ct
+                }
+            )
+            Permission.objects.get_or_create(
+                id=127422,
+                defaults={
+                    'codename': 'grievance_flag_confidential_create',
+                    'name': 'Can create confidential flagged tickets',
+                    'content_type': ct
+                }
+            )
+            
+            # Update the processed config with generated rights
+            TicketConfig.processed_categories['restricted_category']['generated_rights'] = {
+                'restricted_read': 127200,
+                'read': 127201,
+                'create': 127202
+            }
+            TicketConfig.processed_flags['confidential']['generated_rights'] = {
+                'read': 127421,
+                'create': 127422
+            }
+        except Exception as e:
+            cls.stdout.write(f"Warning: Could not create test permissions: {e}")
+    
+    @classmethod
+    def _create_test_users(cls):
+        """Create test users with different permission levels"""
+        from core.models import Role, RoleRight, UserRole
+        from core.utils import TimeUtils
+        
+        # Admin with all permissions - use admin role
+        cls.admin_user = create_test_interactive_user(username='test_admin', roles=[7])  # IMIS Administrator
+        
+        # Create custom role with all grievance permissions
+        admin_role = Role.objects.create(
+            name="Test Grievance Admin",
+            is_blocked=False,
+            is_system=False,
+            audit_user_id=-1,
+        )
+        
+        # Add base permissions
+        base_perms = [127000, 127001, 127002, 127003, 127004, 127005, 127006]
+        # Add test-specific permissions
+        test_perms = [127200, 127201, 127202, 127421, 127422]
+        
+        for perm_id in base_perms + test_perms:
+            try:
+                RoleRight.objects.create(
+                    role=admin_role,
+                    right_id=perm_id,
+                    audit_user_id=-1,
+                    validity_from=TimeUtils.now(),
+                )
+            except Exception:
+                pass
+        
+        # Assign the custom role to admin user
+        UserRole.objects.create(
+            user=cls.admin_user.i_user,
+            role=admin_role,
+            audit_user_id=-1
+        )
+        
+        # Limited user with minimal permissions
+        limited_role = Role.objects.create(
+            name="Test Limited User",
+            is_blocked=False,
+            is_system=False,
+            audit_user_id=-1,
+        )
+        
+        # Only add base query permission
+        RoleRight.objects.create(
+            role=limited_role,
+            right_id=127000,
+            audit_user_id=-1,
+            validity_from=TimeUtils.now(),
+        )
+        
+        cls.limited_user = create_test_interactive_user(username='test_limited', roles=[limited_role.id])
+    
+    @classmethod
+    def _create_test_tickets(cls):
+        """Create test tickets"""
+        cls.tickets = {}
+        
+        # Public ticket - should be visible to all
+        ticket = Ticket(
+            title='Public ticket',
+            category='public_category',
+            flags='public',
+            description='This is a public ticket'
+        )
+        ticket.save(user=cls.admin_user)
+        cls.tickets['public'] = ticket
+        
+        # Create comment on public ticket
+        comment = Comment(
+            ticket=ticket,
+            comment='Public comment',
+            is_resolution=False
+        )
+        comment.save(user=cls.admin_user)
+        cls.public_comment = comment
+        
+        # Restricted category ticket - should only be visible to admin
+        ticket = Ticket(
+            title='Restricted ticket',
+            category='restricted_category',
+            flags='public',
+            description='This is a restricted ticket'
+        )
+        ticket.save(user=cls.admin_user)
+        cls.tickets['restricted'] = ticket
+        
+        # Create comment on restricted ticket
+        comment = Comment(
+            ticket=ticket,
+            comment='Restricted comment',
+            is_resolution=False
+        )
+        comment.save(user=cls.admin_user)
+        cls.restricted_comment = comment
+        
+        # Public category with confidential flag - should only be visible to admin
+        ticket = Ticket(
+            title='Confidential ticket',
+            category='public_category',
+            flags='confidential',
+            description='This is a confidential ticket'
+        )
+        ticket.save(user=cls.admin_user)
+        cls.tickets['confidential'] = ticket
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test data"""
+        # Delete tickets and comments
+        Comment.objects.filter(ticket__in=cls.tickets.values()).delete()
+        Ticket.objects.filter(id__in=[t.id for t in cls.tickets.values()]).delete()
+        super().tearDownClass()
+    
+    def test_ticket_security_with_row_security_enabled(self):
+        """Test ticket filtering with ROW_SECURITY enabled"""
+        # Save original setting
+        original_setting = getattr(settings, 'ROW_SECURITY', True)
+        settings.ROW_SECURITY = True
+        
+        try:
+            # Test admin user
+            queryset = Ticket.objects.all()
+            filtered = Ticket.get_queryset(queryset, self.admin_user)
+            
+            # Admin should see all tickets
+            self.assertEqual(filtered.count(), 3)
+            for name, ticket in self.tickets.items():
+                self.assertTrue(
+                    filtered.filter(id=ticket.id).exists(),
+                    f"Admin should see {name} ticket"
+                )
+            
+            # Test limited user
+            queryset = Ticket.objects.all()
+            filtered = Ticket.get_queryset(queryset, self.limited_user)
+            
+            # Limited user should only see public ticket
+            self.assertEqual(filtered.count(), 1)
+            self.assertTrue(
+                filtered.filter(id=self.tickets['public'].id).exists(),
+                "Limited user should see public ticket"
+            )
+            self.assertFalse(
+                filtered.filter(id=self.tickets['restricted'].id).exists(),
+                "Limited user should not see restricted ticket"
+            )
+            self.assertFalse(
+                filtered.filter(id=self.tickets['confidential'].id).exists(),
+                "Limited user should not see confidential ticket"
+            )
+        finally:
+            # Restore original setting
+            settings.ROW_SECURITY = original_setting
+    
+    def test_ticket_security_with_row_security_disabled(self):
+        """Test ticket filtering with ROW_SECURITY disabled"""
+        # Save original setting
+        original_setting = getattr(settings, 'ROW_SECURITY', True)
+        settings.ROW_SECURITY = False
+        
+        try:
+            # With ROW_SECURITY disabled, all users should see all tickets
+            # Filter to only our test tickets to avoid interference from other tests
+            our_ticket_ids = [t.id for t in self.tickets.values()]
+            queryset = Ticket.objects.filter(id__in=our_ticket_ids)
+            filtered = Ticket.get_queryset(queryset, self.limited_user)
+            
+            # Should see all tickets when security is disabled
+            self.assertEqual(filtered.count(), 3)
+        finally:
+            # Restore original setting
+            settings.ROW_SECURITY = original_setting
+    
+    def test_comment_security_inherits_from_ticket(self):
+        """Test that comment security inherits from parent ticket"""
+        # Save original setting
+        original_setting = getattr(settings, 'ROW_SECURITY', True)
+        settings.ROW_SECURITY = True
+        
+        try:
+            # Test admin user
+            queryset = Comment.objects.all()
+            filtered = Comment.get_queryset(queryset, self.admin_user)
+            
+            # Admin should see all comments
+            self.assertTrue(
+                filtered.filter(id=self.public_comment.id).exists(),
+                "Admin should see public comment"
+            )
+            self.assertTrue(
+                filtered.filter(id=self.restricted_comment.id).exists(),
+                "Admin should see restricted comment"
+            )
+            
+            # Test limited user
+            queryset = Comment.objects.all()
+            filtered = Comment.get_queryset(queryset, self.limited_user)
+            
+            # Limited user should only see comment on public ticket
+            self.assertTrue(
+                filtered.filter(id=self.public_comment.id).exists(),
+                "Limited user should see public comment"
+            )
+            self.assertFalse(
+                filtered.filter(id=self.restricted_comment.id).exists(),
+                "Limited user should not see restricted comment"
+            )
+        finally:
+            # Restore original setting
+            settings.ROW_SECURITY = original_setting
+    
+    def test_graphql_info_object_handling(self):
+        """Test that GraphQL ResolveInfo objects are handled correctly"""
+        from graphql import ResolveInfo
+        from unittest.mock import Mock
+        
+        # Create a mock ResolveInfo with user
+        mock_info = Mock(spec=ResolveInfo)
+        mock_info.context = Mock()
+        mock_info.context.user = self.limited_user
+        
+        # Save original setting
+        original_setting = getattr(settings, 'ROW_SECURITY', True)
+        settings.ROW_SECURITY = True
+        
+        try:
+            # Test that ResolveInfo is properly handled
+            queryset = Ticket.objects.all()
+            filtered = Ticket.get_queryset(queryset, mock_info)
+            
+            # Should extract user from ResolveInfo and apply filtering
+            self.assertEqual(filtered.count(), 1)
+            self.assertTrue(
+                filtered.filter(id=self.tickets['public'].id).exists(),
+                "Should handle ResolveInfo object correctly"
+            )
+        finally:
+            settings.ROW_SECURITY = original_setting

--- a/grievance_social_protection/tests/test_model_security.py
+++ b/grievance_social_protection/tests/test_model_security.py
@@ -11,17 +11,20 @@ from graphql import ResolveInfo
 from core.test_helpers import create_test_interactive_user
 from grievance_social_protection.models import Ticket, Comment
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, collect_all_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, collect_all_rights,
 )
 
 
 class ModelSecurityTest(TestCase):
     """Test security filtering at the model level"""
 
+    _config_snapshot = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._setup_test_config()
+        cls._config_snapshot = cls._setup_test_config()
         cls._create_test_users()
         cls._create_test_tickets()
 
@@ -50,7 +53,7 @@ class ModelSecurityTest(TestCase):
                 }
             ]
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     @classmethod
     def _create_test_users(cls):
@@ -123,6 +126,8 @@ class ModelSecurityTest(TestCase):
         """Clean up test data"""
         Comment.objects.filter(ticket__in=cls.tickets.values()).delete()
         Ticket.objects.filter(id__in=[t.id for t in cls.tickets.values()]).delete()
+        if cls._config_snapshot:
+            restore_grievance_config(cls._config_snapshot)
         super().tearDownClass()
 
     def test_ticket_security_with_row_security_enabled(self):

--- a/grievance_social_protection/tests/test_model_security.py
+++ b/grievance_social_protection/tests/test_model_security.py
@@ -238,10 +238,12 @@ class ModelSecurityTest(TestCase):
         
         try:
             # Test admin user
-            queryset = Ticket.objects.all()
+            # Only test our tickets to avoid interference from other tests
+            test_ticket_ids = [t.id for t in self.tickets.values()]
+            queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, self.admin_user)
             
-            # Admin should see all tickets
+            # Admin should see all 3 test tickets
             self.assertEqual(filtered.count(), 3)
             for name, ticket in self.tickets.items():
                 self.assertTrue(
@@ -250,7 +252,7 @@ class ModelSecurityTest(TestCase):
                 )
             
             # Test limited user
-            queryset = Ticket.objects.all()
+            queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, self.limited_user)
             
             # Limited user should only see public ticket
@@ -344,7 +346,8 @@ class ModelSecurityTest(TestCase):
         
         try:
             # Test that ResolveInfo is properly handled
-            queryset = Ticket.objects.all()
+            test_ticket_ids = [t.id for t in self.tickets.values()]
+            queryset = Ticket.objects.filter(id__in=test_ticket_ids)
             filtered = Ticket.get_queryset(queryset, mock_info)
             
             # Should extract user from ResolveInfo and apply filtering

--- a/grievance_social_protection/tests/test_restricted_view.py
+++ b/grievance_social_protection/tests/test_restricted_view.py
@@ -10,7 +10,6 @@ from graphene.test import Client
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.schema import Query
 from grievance_social_protection.access_control import GrievanceAccessControl
-from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.tests.test_helpers import (
     setup_grievance_config, assign_rights_to_user, get_rights,
 )
@@ -206,9 +205,9 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
         if vbg_ticket:
             # Should see all info including sensitive data
             self.assertEqual(vbg_ticket['description'],
-                            'This contains very sensitive personal information that should be restricted')
+                             'This contains very sensitive personal information that should be restricted')
             self.assertEqual(vbg_ticket['resolution'],
-                            'This is the confidential resolution details')
+                             'This is the confidential resolution details')
             self.assertEqual(vbg_ticket['accessLevel'], 'read')
 
     def test_no_access_user_sees_only_public(self):

--- a/grievance_social_protection/tests/test_restricted_view.py
+++ b/grievance_social_protection/tests/test_restricted_view.py
@@ -3,7 +3,6 @@ Test restricted view functionality for grievance tickets based on user access le
 """
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
-from core.models import Role, RoleRight, UserRole
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 from graphene import Schema
 from graphene.test import Client
@@ -12,33 +11,34 @@ from grievance_social_protection.models import Ticket
 from grievance_social_protection.schema import Query
 from grievance_social_protection.access_control import GrievanceAccessControl
 from grievance_social_protection.apps import TicketConfig
-from grievance_social_protection.rights import GrievanceRightsManager
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, get_rights,
+)
 
 
 class RestrictedViewTest(openIMISGraphQLTestCase):
     """Test that sensitive information is hidden based on user access levels"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        
+
         # Create test users with different access levels
         cls.user_restricted = create_test_interactive_user(username='restricted_viewer', roles=[1])
         cls.user_full_viewer = create_test_interactive_user(username='full_viewer', roles=[1])
         cls.user_manager = create_test_interactive_user(username='manager', roles=[1])
         cls.user_no_access = create_test_interactive_user(username='no_access', roles=[1])
-        
+
         # Create GraphQL schema
         cls.schema = Schema(query=Query)
-        
+
     def setUp(self):
         """Set up test data"""
         super().setUp()
         self._setup_test_config()
-        self._create_test_rights()
         self._assign_rights_to_users()
         self._create_test_ticket()
-    
+
     def _setup_test_config(self):
         """Set up test configuration with restricted categories"""
         cfg = {
@@ -48,7 +48,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
                     'priority': 'Critical',
                     'permissions': ['restricted_read', 'read', 'create'],
                     'default_flags': ['confidential'],
-                    'visible_fields': ['id', 'code', 'title', 'category', 'status', 'priority', 'flags', 'accessLevel']
+                    'visible_fields': ['id', 'code', 'status', 'flags']
                 },
                 {
                     'name': 'public_feedback',
@@ -64,151 +64,37 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
                 'public'
             ]
         }
-        
-        # Process configuration
-        TicketConfig._TicketConfig__process_unified_categories(cfg)
-        TicketConfig._TicketConfig__process_unified_flags(cfg)
-        TicketConfig._TicketConfig__load_config(cfg)
-        
-        # Generate rights
-        self._generate_rights()
-    
-    def _generate_rights(self):
-        """Use the actual GrievanceRightsManager to generate rights"""
-        from grievance_social_protection.rights import GrievanceRightsManager
-        
-        # Generate rights using the real rights manager
-        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
-    
-    def _create_test_rights(self):
-        """Rights in OpenIMIS are just integer IDs, not database objects"""
-        # No need to create Right objects - they're just IDs used in RoleRight.right_id
-        pass
-    
+        setup_grievance_config(cfg)
+
     def _assign_rights_to_users(self):
         """Assign rights to test users through roles"""
-        vbg_rights = TicketConfig.processed_categories.get('vbg_complaint', {}).get('generated_rights', {})
-        conf_rights = TicketConfig.processed_flags.get('confidential', {}).get('generated_rights', {})
-        
-        # Base query permission that all users need
-        base_query_perm = 127000
-        
+        vbg_rights = get_rights('processed_categories', 'vbg_complaint')
+        conf_rights = get_rights('processed_flags', 'confidential')
+        base = 127000
+
         # Restricted viewer - only restricted_read
-        if self.user_restricted.i_user and vbg_rights.get('restricted_read'):
-            role = Role.objects.create(
-                name='TestRestrictedRole',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Add base query permission
-            RoleRight.objects.create(
-                role=role,
-                right_id=base_query_perm,
-                audit_user_id=-1
-            )
-            RoleRight.objects.create(
-                role=role,
-                right_id=vbg_rights['restricted_read'],
-                audit_user_id=-1
-            )
-            if conf_rights.get('restricted_read'):
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=conf_rights['restricted_read'],
-                    audit_user_id=-1
-                )
-            UserRole.objects.create(
-                user=self.user_restricted.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-        
+        restricted_ids = [base]
+        if vbg_rights.get('restricted_read'):
+            restricted_ids.append(vbg_rights['restricted_read'])
+        if conf_rights.get('restricted_read'):
+            restricted_ids.append(conf_rights['restricted_read'])
+        assign_rights_to_user(self.user_restricted, restricted_ids, 'TestRestrictedRole')
+
         # Full viewer - read access
-        if self.user_full_viewer.i_user and vbg_rights.get('read'):
-            role = Role.objects.create(
-                name='TestViewerRole',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Add base query permission
-            RoleRight.objects.create(
-                role=role,
-                right_id=base_query_perm,
-                audit_user_id=-1
-            )
-            RoleRight.objects.create(
-                role=role,
-                right_id=vbg_rights['read'],
-                audit_user_id=-1
-            )
-            if conf_rights.get('read'):
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=conf_rights['read'],
-                    audit_user_id=-1
-                )
-            UserRole.objects.create(
-                user=self.user_full_viewer.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-        
+        viewer_ids = [base]
+        if vbg_rights.get('read'):
+            viewer_ids.append(vbg_rights['read'])
+        if conf_rights.get('read'):
+            viewer_ids.append(conf_rights['read'])
+        assign_rights_to_user(self.user_full_viewer, viewer_ids, 'TestViewerRole')
+
         # Manager - all rights
-        if self.user_manager.i_user:
-            role = Role.objects.create(
-                name='TestManagerRole',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Add base query permission
-            RoleRight.objects.create(
-                role=role,
-                right_id=base_query_perm,
-                audit_user_id=-1
-            )
-            # Add all vbg_complaint rights
-            for right_id in vbg_rights.values():
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=right_id,
-                    audit_user_id=-1
-                )
-            # Add all confidential flag rights
-            for right_id in conf_rights.values():
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=right_id,
-                    audit_user_id=-1
-                )
-            UserRole.objects.create(
-                user=self.user_manager.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-        
-        # No access user - only base query permission, no grievance rights
-        if self.user_no_access.i_user:
-            role = Role.objects.create(
-                name='TestNoAccessRole',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            # Only add base query permission so they can query but get filtered results
-            RoleRight.objects.create(
-                role=role,
-                right_id=base_query_perm,
-                audit_user_id=-1
-            )
-            UserRole.objects.create(
-                user=self.user_no_access.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-    
+        manager_ids = [base] + list(vbg_rights.values()) + list(conf_rights.values())
+        assign_rights_to_user(self.user_manager, manager_ids, 'TestManagerRole')
+
+        # No access user - only base query permission
+        assign_rights_to_user(self.user_no_access, [base], 'TestNoAccessRole')
+
     def _create_test_ticket(self):
         """Create a test ticket with sensitive information"""
         ticket = Ticket(
@@ -226,7 +112,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
         )
         ticket.save(user=self.user_manager.user)
         self.ticket = ticket
-        
+
         public_ticket = Ticket(
             code='PUBLIC001',
             title='Public Feedback',
@@ -239,7 +125,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
         )
         public_ticket.save(user=self.user_manager.user)
         self.public_ticket = public_ticket
-    
+
     def tearDown(self):
         """Clean up test data"""
         if hasattr(self, 'ticket'):
@@ -247,7 +133,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
         if hasattr(self, 'public_ticket'):
             self.public_ticket.delete(user=self.user_manager.user)
         super().tearDown()
-    
+
     def _execute_ticket_query(self, user):
         """Execute GraphQL query to get ticket details"""
         query = '''
@@ -270,28 +156,28 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
                 }
             }
         '''
-        
+
         client = Client(self.schema)
         context = BaseTestContext(user)
         result = client.execute(query, context=context.get_request())
-        
+
         return result
-    
+
     def test_restricted_viewer_sees_limited_info(self):
         """Test that restricted viewer sees only basic information"""
         result = self._execute_ticket_query(self.user_restricted)
-        
+
         self.assertIsNotNone(result)
         self.assertIn('data', result)
-        
+
         edges = result['data']['tickets']['edges']
-        
+
         # Find the VBG ticket
         vbg_ticket = next(
             (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
             None
         )
-        
+
         if vbg_ticket:
             # Should see basic info
             self.assertEqual(vbg_ticket['code'], 'TEST001')
@@ -299,74 +185,74 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
             self.assertEqual(vbg_ticket['category'], '[Restricted]')  # Category should be restricted
             self.assertEqual(vbg_ticket['status'], 'OPEN')
             self.assertIsNone(vbg_ticket['priority'])  # Priority is restricted
-            
+
             # Should NOT see sensitive info
             self.assertEqual(vbg_ticket['description'], '[Restricted]')
             self.assertEqual(vbg_ticket['resolution'], '[Restricted]')
-            
+
             # Should see access level
             self.assertEqual(vbg_ticket['accessLevel'], 'restricted')
-    
+
     def test_full_viewer_sees_all_info(self):
         """Test that full viewer sees all information"""
         result = self._execute_ticket_query(self.user_full_viewer)
-        
+
         edges = result['data']['tickets']['edges']
         vbg_ticket = next(
             (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
             None
         )
-        
+
         if vbg_ticket:
             # Should see all info including sensitive data
-            self.assertEqual(vbg_ticket['description'], 
+            self.assertEqual(vbg_ticket['description'],
                             'This contains very sensitive personal information that should be restricted')
-            self.assertEqual(vbg_ticket['resolution'], 
+            self.assertEqual(vbg_ticket['resolution'],
                             'This is the confidential resolution details')
             self.assertEqual(vbg_ticket['accessLevel'], 'read')
-    
+
     def test_no_access_user_sees_only_public(self):
         """Test that user with no access sees only public tickets"""
         result = self._execute_ticket_query(self.user_no_access)
-        
+
         edges = result['data']['tickets']['edges']
-        
+
         # Should only see public ticket
         codes = [edge['node']['code'] for edge in edges]
         self.assertIn('PUBLIC001', codes)
         self.assertNotIn('TEST001', codes)
-    
+
     def test_manager_has_full_access(self):
         """Test that manager sees everything and has full access"""
         result = self._execute_ticket_query(self.user_manager)
-        
+
         edges = result['data']['tickets']['edges']
         vbg_ticket = next(
             (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
             None
         )
-        
+
         if vbg_ticket:
             # Should see all info
             self.assertNotEqual(vbg_ticket['description'], '[Restricted]')
             self.assertNotEqual(vbg_ticket['resolution'], '[Restricted]')
             self.assertEqual(vbg_ticket['accessLevel'], 'full')
-    
+
     def test_public_ticket_accessible_to_all(self):
         """Test that tickets without restrictions are accessible to all"""
         # Even user with no rights should see full info for public tickets
         result = self._execute_ticket_query(self.user_no_access)
-        
+
         edges = result['data']['tickets']['edges']
         public_data = next(
             (edge['node'] for edge in edges if edge['node']['code'] == 'PUBLIC001'),
             None
         )
-        
+
         self.assertIsNotNone(public_data)
         self.assertEqual(public_data['description'], 'This is public information')
         self.assertEqual(public_data['accessLevel'], 'full')  # No restrictions
-    
+
     def test_access_level_calculation(self):
         """Test access level calculation based on actual rights"""
         # Test with real user rights
@@ -374,17 +260,17 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
             self.user_restricted, 'vbg_complaint', 'confidential'
         )
         self.assertEqual(access_level, 'restricted')
-        
+
         access_level = GrievanceAccessControl.get_user_access_level(
             self.user_full_viewer, 'vbg_complaint', 'confidential'
         )
         self.assertEqual(access_level, 'read')
-        
+
         access_level = GrievanceAccessControl.get_user_access_level(
             self.user_manager, 'vbg_complaint', 'confidential'
         )
         self.assertEqual(access_level, 'full')
-        
+
         access_level = GrievanceAccessControl.get_user_access_level(
             self.user_no_access, 'vbg_complaint', 'confidential'
         )
@@ -393,57 +279,39 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
 
 class RestrictedViewIntegrationTest(TestCase):
     """Integration tests for restricted view with actual rights checking"""
-    
+
     def setUp(self):
         """Set up test environment"""
         self.user = create_test_interactive_user(username='test_rights_user', roles=[1])
         self._setup_config_and_rights()
-    
+
     def _setup_config_and_rights(self):
         """Set up configuration and create rights"""
-        # Simple test config
         cfg = {
             'grievance_types': [{
                 'name': 'test_category',
-                'permissions': ['restricted_read', 'read', 'create']  # Changed 'write' to 'create' and added restricted_read
+                'permissions': ['restricted_read', 'read', 'create']
             }]
         }
-        
-        TicketConfig._TicketConfig__process_unified_categories(cfg)
-        TicketConfig._TicketConfig__load_config(cfg)
-        
-        # Use the actual GrievanceRightsManager to generate rights
-        from grievance_social_protection.rights import GrievanceRightsManager
-        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
-    
+        setup_grievance_config(cfg)
+
     def test_rights_based_filtering(self):
         """Test that rights-based filtering works correctly"""
         # Give user only restricted_read right
-        cat_info = TicketConfig.processed_categories.get('test_category', {})
-        if self.user.i_user and cat_info.get('generated_rights', {}).get('restricted_read'):
-            role = Role.objects.create(
-                name='TestRestrictedOnly',
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
+        cat_rights = get_rights('processed_categories', 'test_category')
+        if self.user.i_user and cat_rights.get('restricted_read'):
+            assign_rights_to_user(
+                self.user,
+                [cat_rights['restricted_read']],
+                role_name='TestRestrictedOnly',
             )
-            RoleRight.objects.create(
-                role=role,
-                right_id=cat_info['generated_rights']['restricted_read'],
-                audit_user_id=-1
-            )
-            UserRole.objects.create(
-                user=self.user.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-            
+
             # User should have restricted access
             access_level = GrievanceAccessControl.get_user_access_level(
                 self.user, 'test_category'
             )
             self.assertEqual(access_level, 'restricted')
-            
+
             # User should be able to check restricted access
             self.assertTrue(
                 GrievanceAccessControl.check_category_access(
@@ -455,8 +323,7 @@ class RestrictedViewIntegrationTest(TestCase):
                     self.user, 'test_category', 'read'
                 )
             )
-    
+
     def tearDown(self):
         """Clean up test data"""
-        # No Right objects to clean up - they're just IDs
         super().tearDown()

--- a/grievance_social_protection/tests/test_restricted_view.py
+++ b/grievance_social_protection/tests/test_restricted_view.py
@@ -11,7 +11,8 @@ from grievance_social_protection.models import Ticket
 from grievance_social_protection.schema import Query
 from grievance_social_protection.access_control import GrievanceAccessControl
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, get_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, get_rights,
 )
 
 
@@ -34,7 +35,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
     def setUp(self):
         """Set up test data"""
         super().setUp()
-        self._setup_test_config()
+        self._snapshot = self._setup_test_config()
         self._assign_rights_to_users()
         self._create_test_ticket()
 
@@ -63,7 +64,7 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
                 'public'
             ]
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     def _assign_rights_to_users(self):
         """Assign rights to test users through roles"""
@@ -126,11 +127,12 @@ class RestrictedViewTest(openIMISGraphQLTestCase):
         self.public_ticket = public_ticket
 
     def tearDown(self):
-        """Clean up test data"""
+        """Clean up test data and restore config"""
         if hasattr(self, 'ticket'):
             self.ticket.delete(user=self.user_manager.user)
         if hasattr(self, 'public_ticket'):
             self.public_ticket.delete(user=self.user_manager.user)
+        restore_grievance_config(self._snapshot)
         super().tearDown()
 
     def _execute_ticket_query(self, user):
@@ -282,7 +284,7 @@ class RestrictedViewIntegrationTest(TestCase):
     def setUp(self):
         """Set up test environment"""
         self.user = create_test_interactive_user(username='test_rights_user', roles=[1])
-        self._setup_config_and_rights()
+        self._snapshot = self._setup_config_and_rights()
 
     def _setup_config_and_rights(self):
         """Set up configuration and create rights"""
@@ -292,7 +294,7 @@ class RestrictedViewIntegrationTest(TestCase):
                 'permissions': ['restricted_read', 'read', 'create']
             }]
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     def test_rights_based_filtering(self):
         """Test that rights-based filtering works correctly"""
@@ -325,4 +327,5 @@ class RestrictedViewIntegrationTest(TestCase):
 
     def tearDown(self):
         """Clean up test data"""
+        restore_grievance_config(self._snapshot)
         super().tearDown()

--- a/grievance_social_protection/tests/test_restricted_view.py
+++ b/grievance_social_protection/tests/test_restricted_view.py
@@ -1,0 +1,462 @@
+"""
+Test restricted view functionality for grievance tickets based on user access levels.
+"""
+from django.test import TestCase
+from core.test_helpers import create_test_interactive_user
+from core.models import Role, RoleRight, UserRole
+from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
+from graphene import Schema
+from graphene.test import Client
+
+from grievance_social_protection.models import Ticket
+from grievance_social_protection.schema import Query
+from grievance_social_protection.access_control import GrievanceAccessControl
+from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.rights import GrievanceRightsManager
+
+
+class RestrictedViewTest(openIMISGraphQLTestCase):
+    """Test that sensitive information is hidden based on user access levels"""
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        
+        # Create test users with different access levels
+        cls.user_restricted = create_test_interactive_user(username='restricted_viewer', roles=[1])
+        cls.user_full_viewer = create_test_interactive_user(username='full_viewer', roles=[1])
+        cls.user_manager = create_test_interactive_user(username='manager', roles=[1])
+        cls.user_no_access = create_test_interactive_user(username='no_access', roles=[1])
+        
+        # Create GraphQL schema
+        cls.schema = Schema(query=Query)
+        
+    def setUp(self):
+        """Set up test data"""
+        super().setUp()
+        self._setup_test_config()
+        self._create_test_rights()
+        self._assign_rights_to_users()
+        self._create_test_ticket()
+    
+    def _setup_test_config(self):
+        """Set up test configuration with restricted categories"""
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'vbg_complaint',
+                    'priority': 'Critical',
+                    'permissions': ['restricted_read', 'read', 'create'],
+                    'default_flags': ['confidential'],
+                    'visible_fields': ['id', 'code', 'title', 'category', 'status', 'priority', 'flags', 'accessLevel']
+                },
+                {
+                    'name': 'public_feedback',
+                    'priority': 'Low'
+                }
+            ],
+            'grievance_flags': [
+                {
+                    'name': 'confidential',
+                    'priority': 'Critical',
+                    'permissions': ['restricted_read', 'read', 'create']
+                },
+                'public'
+            ]
+        }
+        
+        # Process configuration
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        TicketConfig._TicketConfig__process_unified_flags(cfg)
+        TicketConfig._TicketConfig__load_config(cfg)
+        
+        # Generate rights
+        self._generate_rights()
+    
+    def _generate_rights(self):
+        """Use the actual GrievanceRightsManager to generate rights"""
+        from grievance_social_protection.rights import GrievanceRightsManager
+        
+        # Generate rights using the real rights manager
+        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
+    
+    def _create_test_rights(self):
+        """Rights in OpenIMIS are just integer IDs, not database objects"""
+        # No need to create Right objects - they're just IDs used in RoleRight.right_id
+        pass
+    
+    def _assign_rights_to_users(self):
+        """Assign rights to test users through roles"""
+        vbg_rights = TicketConfig.processed_categories.get('vbg_complaint', {}).get('generated_rights', {})
+        conf_rights = TicketConfig.processed_flags.get('confidential', {}).get('generated_rights', {})
+        
+        # Base query permission that all users need
+        base_query_perm = 127000
+        
+        # Restricted viewer - only restricted_read
+        if self.user_restricted.i_user and vbg_rights.get('restricted_read'):
+            role = Role.objects.create(
+                name='TestRestrictedRole',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Add base query permission
+            RoleRight.objects.create(
+                role=role,
+                right_id=base_query_perm,
+                audit_user_id=-1
+            )
+            RoleRight.objects.create(
+                role=role,
+                right_id=vbg_rights['restricted_read'],
+                audit_user_id=-1
+            )
+            if conf_rights.get('restricted_read'):
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=conf_rights['restricted_read'],
+                    audit_user_id=-1
+                )
+            UserRole.objects.create(
+                user=self.user_restricted.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+        
+        # Full viewer - read access
+        if self.user_full_viewer.i_user and vbg_rights.get('read'):
+            role = Role.objects.create(
+                name='TestViewerRole',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Add base query permission
+            RoleRight.objects.create(
+                role=role,
+                right_id=base_query_perm,
+                audit_user_id=-1
+            )
+            RoleRight.objects.create(
+                role=role,
+                right_id=vbg_rights['read'],
+                audit_user_id=-1
+            )
+            if conf_rights.get('read'):
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=conf_rights['read'],
+                    audit_user_id=-1
+                )
+            UserRole.objects.create(
+                user=self.user_full_viewer.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+        
+        # Manager - all rights
+        if self.user_manager.i_user:
+            role = Role.objects.create(
+                name='TestManagerRole',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Add base query permission
+            RoleRight.objects.create(
+                role=role,
+                right_id=base_query_perm,
+                audit_user_id=-1
+            )
+            # Add all vbg_complaint rights
+            for right_id in vbg_rights.values():
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=right_id,
+                    audit_user_id=-1
+                )
+            # Add all confidential flag rights
+            for right_id in conf_rights.values():
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=right_id,
+                    audit_user_id=-1
+                )
+            UserRole.objects.create(
+                user=self.user_manager.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+        
+        # No access user - only base query permission, no grievance rights
+        if self.user_no_access.i_user:
+            role = Role.objects.create(
+                name='TestNoAccessRole',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            # Only add base query permission so they can query but get filtered results
+            RoleRight.objects.create(
+                role=role,
+                right_id=base_query_perm,
+                audit_user_id=-1
+            )
+            UserRole.objects.create(
+                user=self.user_no_access.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+    
+    def _create_test_ticket(self):
+        """Create a test ticket with sensitive information"""
+        ticket = Ticket(
+            code='TEST001',
+            title='Sensitive VBG Case',
+            description='This contains very sensitive personal information that should be restricted',
+            category='vbg_complaint',
+            flags='confidential',
+            priority='Critical',
+            status='OPEN',
+            channel='Web',
+            reporter_id=1,
+            reporter_type_id=1,
+            resolution='This is the confidential resolution details'
+        )
+        ticket.save(user=self.user_manager.user)
+        self.ticket = ticket
+        
+        public_ticket = Ticket(
+            code='PUBLIC001',
+            title='Public Feedback',
+            description='This is public information',
+            category='public_feedback',
+            flags='public',
+            priority='Low',
+            status='OPEN',
+            channel='Web'
+        )
+        public_ticket.save(user=self.user_manager.user)
+        self.public_ticket = public_ticket
+    
+    def tearDown(self):
+        """Clean up test data"""
+        if hasattr(self, 'ticket'):
+            self.ticket.delete(user=self.user_manager.user)
+        if hasattr(self, 'public_ticket'):
+            self.public_ticket.delete(user=self.user_manager.user)
+        super().tearDown()
+    
+    def _execute_ticket_query(self, user):
+        """Execute GraphQL query to get ticket details"""
+        query = '''
+            query {
+                tickets {
+                    edges {
+                        node {
+                            id
+                            code
+                            title
+                            description
+                            category
+                            flags
+                            priority
+                            status
+                            resolution
+                            accessLevel
+                        }
+                    }
+                }
+            }
+        '''
+        
+        client = Client(self.schema)
+        context = BaseTestContext(user)
+        result = client.execute(query, context=context.get_request())
+        
+        return result
+    
+    def test_restricted_viewer_sees_limited_info(self):
+        """Test that restricted viewer sees only basic information"""
+        result = self._execute_ticket_query(self.user_restricted)
+        
+        self.assertIsNotNone(result)
+        self.assertIn('data', result)
+        
+        edges = result['data']['tickets']['edges']
+        
+        # Find the VBG ticket
+        vbg_ticket = next(
+            (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
+            None
+        )
+        
+        if vbg_ticket:
+            # Should see basic info
+            self.assertEqual(vbg_ticket['code'], 'TEST001')
+            self.assertEqual(vbg_ticket['title'], '[Restricted]')  # Title should be restricted
+            self.assertEqual(vbg_ticket['category'], '[Restricted]')  # Category should be restricted
+            self.assertEqual(vbg_ticket['status'], 'OPEN')
+            self.assertIsNone(vbg_ticket['priority'])  # Priority is restricted
+            
+            # Should NOT see sensitive info
+            self.assertEqual(vbg_ticket['description'], '[Restricted]')
+            self.assertEqual(vbg_ticket['resolution'], '[Restricted]')
+            
+            # Should see access level
+            self.assertEqual(vbg_ticket['accessLevel'], 'restricted')
+    
+    def test_full_viewer_sees_all_info(self):
+        """Test that full viewer sees all information"""
+        result = self._execute_ticket_query(self.user_full_viewer)
+        
+        edges = result['data']['tickets']['edges']
+        vbg_ticket = next(
+            (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
+            None
+        )
+        
+        if vbg_ticket:
+            # Should see all info including sensitive data
+            self.assertEqual(vbg_ticket['description'], 
+                            'This contains very sensitive personal information that should be restricted')
+            self.assertEqual(vbg_ticket['resolution'], 
+                            'This is the confidential resolution details')
+            self.assertEqual(vbg_ticket['accessLevel'], 'read')
+    
+    def test_no_access_user_sees_only_public(self):
+        """Test that user with no access sees only public tickets"""
+        result = self._execute_ticket_query(self.user_no_access)
+        
+        edges = result['data']['tickets']['edges']
+        
+        # Should only see public ticket
+        codes = [edge['node']['code'] for edge in edges]
+        self.assertIn('PUBLIC001', codes)
+        self.assertNotIn('TEST001', codes)
+    
+    def test_manager_has_full_access(self):
+        """Test that manager sees everything and has full access"""
+        result = self._execute_ticket_query(self.user_manager)
+        
+        edges = result['data']['tickets']['edges']
+        vbg_ticket = next(
+            (edge['node'] for edge in edges if edge['node']['code'] == 'TEST001'),
+            None
+        )
+        
+        if vbg_ticket:
+            # Should see all info
+            self.assertNotEqual(vbg_ticket['description'], '[Restricted]')
+            self.assertNotEqual(vbg_ticket['resolution'], '[Restricted]')
+            self.assertEqual(vbg_ticket['accessLevel'], 'full')
+    
+    def test_public_ticket_accessible_to_all(self):
+        """Test that tickets without restrictions are accessible to all"""
+        # Even user with no rights should see full info for public tickets
+        result = self._execute_ticket_query(self.user_no_access)
+        
+        edges = result['data']['tickets']['edges']
+        public_data = next(
+            (edge['node'] for edge in edges if edge['node']['code'] == 'PUBLIC001'),
+            None
+        )
+        
+        self.assertIsNotNone(public_data)
+        self.assertEqual(public_data['description'], 'This is public information')
+        self.assertEqual(public_data['accessLevel'], 'full')  # No restrictions
+    
+    def test_access_level_calculation(self):
+        """Test access level calculation based on actual rights"""
+        # Test with real user rights
+        access_level = GrievanceAccessControl.get_user_access_level(
+            self.user_restricted, 'vbg_complaint', 'confidential'
+        )
+        self.assertEqual(access_level, 'restricted')
+        
+        access_level = GrievanceAccessControl.get_user_access_level(
+            self.user_full_viewer, 'vbg_complaint', 'confidential'
+        )
+        self.assertEqual(access_level, 'read')
+        
+        access_level = GrievanceAccessControl.get_user_access_level(
+            self.user_manager, 'vbg_complaint', 'confidential'
+        )
+        self.assertEqual(access_level, 'full')
+        
+        access_level = GrievanceAccessControl.get_user_access_level(
+            self.user_no_access, 'vbg_complaint', 'confidential'
+        )
+        self.assertEqual(access_level, 'none')
+
+
+class RestrictedViewIntegrationTest(TestCase):
+    """Integration tests for restricted view with actual rights checking"""
+    
+    def setUp(self):
+        """Set up test environment"""
+        self.user = create_test_interactive_user(username='test_rights_user', roles=[1])
+        self._setup_config_and_rights()
+    
+    def _setup_config_and_rights(self):
+        """Set up configuration and create rights"""
+        # Simple test config
+        cfg = {
+            'grievance_types': [{
+                'name': 'test_category',
+                'permissions': ['restricted_read', 'read', 'create']  # Changed 'write' to 'create' and added restricted_read
+            }]
+        }
+        
+        TicketConfig._TicketConfig__process_unified_categories(cfg)
+        TicketConfig._TicketConfig__load_config(cfg)
+        
+        # Use the actual GrievanceRightsManager to generate rights
+        from grievance_social_protection.rights import GrievanceRightsManager
+        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
+    
+    def test_rights_based_filtering(self):
+        """Test that rights-based filtering works correctly"""
+        # Give user only restricted_read right
+        cat_info = TicketConfig.processed_categories.get('test_category', {})
+        if self.user.i_user and cat_info.get('generated_rights', {}).get('restricted_read'):
+            role = Role.objects.create(
+                name='TestRestrictedOnly',
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            RoleRight.objects.create(
+                role=role,
+                right_id=cat_info['generated_rights']['restricted_read'],
+                audit_user_id=-1
+            )
+            UserRole.objects.create(
+                user=self.user.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+            
+            # User should have restricted access
+            access_level = GrievanceAccessControl.get_user_access_level(
+                self.user, 'test_category'
+            )
+            self.assertEqual(access_level, 'restricted')
+            
+            # User should be able to check restricted access
+            self.assertTrue(
+                GrievanceAccessControl.check_category_access(
+                    self.user, 'test_category', 'restricted_read'
+                )
+            )
+            self.assertFalse(
+                GrievanceAccessControl.check_category_access(
+                    self.user, 'test_category', 'read'
+                )
+            )
+    
+    def tearDown(self):
+        """Clean up test data"""
+        # No Right objects to clean up - they're just IDs
+        super().tearDown()

--- a/grievance_social_protection/tests/test_rights_manager.py
+++ b/grievance_social_protection/tests/test_rights_manager.py
@@ -442,12 +442,14 @@ class TestGenerateAutomaticRights(TestCase):
 
     def test_reuses_existing_permissions(self):
         """Test that existing permissions are reused instead of creating duplicates"""
-        # First, create a permission manually
-        existing_perm = Permission.objects.create(
+        # First, create a permission manually (use update_or_create for --keepdb safety)
+        existing_perm, _ = Permission.objects.update_or_create(
             id=127100,
-            codename='read_existing_cat_grievance',
-            name='Can read existing_cat tickets',
-            content_type=self.ct
+            defaults={
+                'codename': 'read_existing_cat_grievance',
+                'name': 'Can read existing_cat tickets',
+                'content_type': self.ct
+            }
         )
 
         app_config = self._create_app_config()
@@ -548,8 +550,8 @@ class TestGenerateAutomaticRights(TestCase):
 
         self.assertNotEqual(id_one, id_two)
 
-    def test_updates_default_cfg(self):
-        """Test that DEFAULT_CFG is updated with generated rights"""
+    def test_sets_rights_as_app_config_attribute(self):
+        """Test that generated rights are set as attributes on app_config"""
         app_config = self._create_app_config()
         app_config.processed_categories = {
             'cfg_test': {
@@ -563,8 +565,8 @@ class TestGenerateAutomaticRights(TestCase):
 
         GrievanceRightsManager.generate_automatic_rights(app_config)
 
-        # Verify the right was added to DEFAULT_CFG
-        self.assertIn(expected_key, DEFAULT_CFG)
+        # Verify the right was set as attribute on app_config
+        self.assertTrue(hasattr(app_config, expected_key))
 
     def test_handles_mixed_categories_and_flags(self):
         """Test processing both categories and flags together"""
@@ -635,6 +637,10 @@ class TestProcessPermissions(TestCase):
     def setUp(self):
         """Set up test fixtures"""
         self.ct = ContentType.objects.get_for_model(Ticket)
+        # Pre-populate used_ids from DB for --keepdb safety
+        self.db_used_ids = set(Permission.objects.filter(
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).values_list('id', flat=True))
 
     def tearDown(self):
         """Clean up created test permissions"""
@@ -651,7 +657,7 @@ class TestProcessPermissions(TestCase):
             'generated_rights': {}
         }
         existing_by_codename = {}
-        used_ids = set()
+        used_ids = self.db_used_ids.copy()
         all_rights = {}
 
         GrievanceRightsManager._process_permissions(
@@ -674,7 +680,7 @@ class TestProcessPermissions(TestCase):
             'generated_rights': {}
         }
         existing_by_codename = {}
-        used_ids = set()
+        used_ids = self.db_used_ids.copy()
         all_rights = {}
 
         GrievanceRightsManager._process_permissions(
@@ -692,7 +698,7 @@ class TestProcessPermissions(TestCase):
             'generated_rights': {}
         }
         existing_by_codename = {}
-        used_ids = set()
+        used_ids = self.db_used_ids.copy()
         all_rights = {}
 
         GrievanceRightsManager._process_permissions(
@@ -700,18 +706,20 @@ class TestProcessPermissions(TestCase):
             existing_by_codename, used_ids, self.ct, all_rights
         )
 
-        # generated_rights should not be added since permissions is empty
-        self.assertNotIn('generated_rights', item_info)
+        # generated_rights should be empty since permissions is empty
+        self.assertEqual(item_info['generated_rights'], {})
         self.assertEqual(len(all_rights), 0)
 
     def test_reuses_existing_permission(self):
         """Test that existing permissions are reused"""
-        # Create existing permission
-        existing_perm = Permission.objects.create(
+        # Create existing permission (use update_or_create for --keepdb safety)
+        existing_perm, _ = Permission.objects.update_or_create(
             id=127150,
-            codename='read_reuse_test_grievance',
-            name='Can read reuse_test tickets',
-            content_type=self.ct
+            defaults={
+                'codename': 'read_reuse_test_grievance',
+                'name': 'Can read reuse_test tickets',
+                'content_type': self.ct
+            }
         )
 
         item_info = {
@@ -719,7 +727,7 @@ class TestProcessPermissions(TestCase):
             'generated_rights': {}
         }
         existing_by_codename = {'read_reuse_test_grievance': existing_perm}
-        used_ids = {127150}
+        used_ids = self.db_used_ids | {127150}
         all_rights = {}
 
         GrievanceRightsManager._process_permissions(
@@ -737,7 +745,8 @@ class TestProcessPermissions(TestCase):
             'generated_rights': {}
         }
         existing_by_codename = {}
-        used_ids = set()
+        used_ids = self.db_used_ids.copy()
+        initial_count = len(used_ids)
         all_rights = {}
 
         GrievanceRightsManager._process_permissions(
@@ -745,7 +754,7 @@ class TestProcessPermissions(TestCase):
             existing_by_codename, used_ids, self.ct, all_rights
         )
 
-        # used_ids should now contain the new ID
-        self.assertGreater(len(used_ids), 0)
+        # used_ids should now contain more IDs than before
+        self.assertGreater(len(used_ids), initial_count)
         new_id = item_info['generated_rights']['read']
         self.assertIn(new_id, used_ids)

--- a/grievance_social_protection/tests/test_rights_manager.py
+++ b/grievance_social_protection/tests/test_rights_manager.py
@@ -1,0 +1,751 @@
+"""
+Tests for GrievanceRightsManager class.
+
+This module provides comprehensive test coverage for:
+- generate_automatic_rights(): Permission creation and management
+- _get_next_available_id(): ID generation with suffix pattern
+- _generate_permission_fields(): Codename and permission name generation
+"""
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from grievance_social_protection.models import Ticket
+from grievance_social_protection.rights import GrievanceRightsManager
+from grievance_social_protection.apps import TicketConfig, DEFAULT_CFG
+import grievance_social_protection
+
+
+class TestGetNextAvailableId(TestCase):
+    """Tests for GrievanceRightsManager._get_next_available_id()"""
+
+    def test_read_permission_suffix_zero(self):
+        """Test that read permission gets suffix 0"""
+        used_ids = set()
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+
+        self.assertEqual(next_id % 10, 0)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0)
+
+    def test_create_permission_suffix_one(self):
+        """Test that create permission gets suffix 1"""
+        used_ids = set()
+        next_id = GrievanceRightsManager._get_next_available_id('create', used_ids)
+
+        self.assertEqual(next_id % 10, 1)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 1)
+
+    def test_update_permission_suffix_two(self):
+        """Test that update permission gets suffix 2"""
+        used_ids = set()
+        next_id = GrievanceRightsManager._get_next_available_id('update', used_ids)
+
+        self.assertEqual(next_id % 10, 2)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 2)
+
+    def test_delete_permission_suffix_three(self):
+        """Test that delete permission gets suffix 3"""
+        used_ids = set()
+        next_id = GrievanceRightsManager._get_next_available_id('delete', used_ids)
+
+        self.assertEqual(next_id % 10, 3)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 3)
+
+    def test_restricted_read_permission_suffix_four(self):
+        """Test that restricted_read permission gets suffix 4"""
+        used_ids = set()
+        next_id = GrievanceRightsManager._get_next_available_id('restricted_read', used_ids)
+
+        self.assertEqual(next_id % 10, 4)
+        self.assertEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 4)
+
+    def test_skips_used_ids_maintains_suffix(self):
+        """Test that when base ID is used, it increments by 10 to maintain suffix"""
+        # Mark the base read ID as used
+        base_read_id = GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0  # 127100
+        used_ids = {base_read_id}
+
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+
+        # Should be 127110 (base + 10), maintaining suffix 0
+        self.assertEqual(next_id, 127110)
+        self.assertEqual(next_id % 10, 0)
+
+    def test_skips_multiple_used_ids(self):
+        """Test that multiple used IDs are properly skipped"""
+        # Mark first three read slots as used
+        used_ids = {127100, 127110, 127120}
+
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+
+        self.assertEqual(next_id, 127130)
+        self.assertEqual(next_id % 10, 0)
+
+    def test_mixed_used_ids_different_suffixes(self):
+        """Test with mixed IDs from different permission types"""
+        # Mix of read (0), create (1), update (2) used IDs
+        used_ids = {127100, 127101, 127102, 127110, 127111}
+
+        # Read should skip to 127120
+        read_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+        self.assertEqual(read_id, 127120)
+
+        # Create should skip to 127121
+        create_id = GrievanceRightsManager._get_next_available_id('create', used_ids)
+        self.assertEqual(create_id, 127121)
+
+        # Delete (suffix 3) should get 127103 since it's not used
+        delete_id = GrievanceRightsManager._get_next_available_id('delete', used_ids)
+        self.assertEqual(delete_id, 127103)
+
+    def test_raises_error_when_range_exhausted(self):
+        """Test that ValueError is raised when no IDs available"""
+        # Create set of all possible IDs with suffix 0 (read) in the range
+        used_ids = set()
+        current = GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0
+        while current <= GrievanceRightsManager.GRIEVANCE_RIGHT_MAX:
+            used_ids.add(current)
+            current += 10
+
+        with self.assertRaises(ValueError) as context:
+            GrievanceRightsManager._get_next_available_id('read', used_ids)
+
+        self.assertIn('No available ID', str(context.exception))
+        self.assertIn('read', str(context.exception))
+
+    def test_boundary_id_at_max(self):
+        """Test behavior when approaching the maximum ID"""
+        # Use all IDs except the last valid one
+        used_ids = set()
+        current = GrievanceRightsManager.GRIEVANCE_RIGHT_BASE + 0
+        # Leave room for exactly one more ID with suffix 0
+        while current <= GrievanceRightsManager.GRIEVANCE_RIGHT_MAX - 10:
+            used_ids.add(current)
+            current += 10
+
+        # Should still find the last available ID
+        next_id = GrievanceRightsManager._get_next_available_id('read', used_ids)
+        self.assertLessEqual(next_id, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        self.assertEqual(next_id % 10, 0)
+
+
+class TestGeneratePermissionFields(TestCase):
+    """Tests for GrievanceRightsManager._generate_permission_fields()"""
+
+    def test_category_read_permission(self):
+        """Test generating read permission fields for a category"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'complaint', is_flag=False
+        )
+
+        self.assertEqual(codename, 'read_complaint_grievance')
+        self.assertEqual(permission_name, 'Can read complaint tickets')
+        self.assertEqual(right_name, 'gql_query_complaint_category_tickets_perms')
+
+    def test_category_create_permission(self):
+        """Test generating create permission fields for a category"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'create', 'feedback', is_flag=False
+        )
+
+        self.assertEqual(codename, 'create_feedback_grievance')
+        self.assertEqual(permission_name, 'Can create feedback tickets')
+        self.assertEqual(right_name, 'gql_mutation_create_feedback_category_tickets_perms')
+
+    def test_category_update_permission(self):
+        """Test generating update permission fields for a category"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'update', 'appeal', is_flag=False
+        )
+
+        self.assertEqual(codename, 'update_appeal_grievance')
+        self.assertEqual(permission_name, 'Can update appeal tickets')
+        self.assertEqual(right_name, 'gql_mutation_update_appeal_category_tickets_perms')
+
+    def test_category_delete_permission(self):
+        """Test generating delete permission fields for a category"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'delete', 'test_category', is_flag=False
+        )
+
+        self.assertEqual(codename, 'delete_test_category_grievance')
+        self.assertEqual(permission_name, 'Can delete test_category tickets')
+        self.assertEqual(right_name, 'gql_mutation_delete_test_category_category_tickets_perms')
+
+    def test_category_restricted_read_permission(self):
+        """Test generating restricted_read permission fields for a category"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'restricted_read', 'sensitive', is_flag=False
+        )
+
+        self.assertEqual(codename, 'restricted_read_sensitive_grievance')
+        self.assertEqual(permission_name, 'Can restricted read sensitive tickets')
+        self.assertEqual(right_name, 'gql_query_restricted_sensitive_category_tickets_perms')
+
+    def test_flag_read_permission(self):
+        """Test generating read permission fields for a flag"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'urgent', is_flag=True
+        )
+
+        self.assertEqual(codename, 'read_flag_urgent_grievance')
+        self.assertEqual(permission_name, 'Can read urgent flagged tickets')
+        self.assertEqual(right_name, 'gql_query_urgent_flagged_tickets_perms')
+
+    def test_flag_create_permission(self):
+        """Test generating create permission fields for a flag"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'create', 'confidential', is_flag=True
+        )
+
+        self.assertEqual(codename, 'create_flag_confidential_grievance')
+        self.assertEqual(permission_name, 'Can create confidential flagged tickets')
+        self.assertEqual(right_name, 'gql_mutation_create_confidential_flagged_tickets_perms')
+
+    def test_name_with_spaces_normalized(self):
+        """Test that names with spaces are normalized properly"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'Category With Spaces', is_flag=False
+        )
+
+        # Codename should have underscores instead of spaces
+        self.assertEqual(codename, 'read_category_with_spaces_grievance')
+        # Permission name keeps the readable form
+        self.assertEqual(permission_name, 'Can read Category With Spaces tickets')
+        # Right name should have underscores
+        self.assertEqual(right_name, 'gql_query_category_with_spaces_category_tickets_perms')
+
+    def test_name_with_special_characters(self):
+        """Test that special characters are removed from codename"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'Category-A (Type 1)', is_flag=False
+        )
+
+        # Special chars and parenthetical content removed
+        self.assertEqual(codename, 'read_category_a_grievance')
+        # Permission name has parenthetical content removed
+        self.assertEqual(permission_name, 'Can read Category-A tickets')
+        # Right name normalized
+        self.assertEqual(right_name, 'gql_query_category_a_category_tickets_perms')
+
+    def test_name_with_parentheses_stripped(self):
+        """Test that parenthetical content is removed"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'VBG Complaint (Violence)', is_flag=False
+        )
+
+        # Parentheses content should be removed
+        self.assertNotIn('violence', codename.lower())
+        self.assertNotIn('(', permission_name)
+
+    def test_hierarchical_category_name(self):
+        """Test permission generation for hierarchical category names"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', 'parent|child', is_flag=False
+        )
+
+        # Pipe character should become underscore
+        self.assertEqual(codename, 'read_parent_child_grievance')
+        self.assertEqual(permission_name, 'Can read parent|child tickets')
+
+    def test_codename_truncation_for_long_names(self):
+        """Test that long names are truncated to fit Django's 100 char limit"""
+        # Create a very long category name
+        long_name = 'a' * 150
+
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', long_name, is_flag=False
+        )
+
+        # Codename should not exceed 100 characters
+        self.assertLessEqual(len(codename), GrievanceRightsManager.CODENAME_MAX_LENGTH)
+        # Should still end with _grievance
+        self.assertTrue(codename.endswith('_grievance'))
+
+    def test_permission_name_truncation_for_long_names(self):
+        """Test that permission names are truncated to fit Django's 255 char limit"""
+        # Create a very long category name
+        long_name = 'a' * 300
+
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'read', long_name, is_flag=False
+        )
+
+        # Permission name should not exceed 255 characters
+        self.assertLessEqual(len(permission_name), GrievanceRightsManager.PERMISSION_NAME_MAX_LENGTH)
+
+    def test_underscore_in_permission_type_display(self):
+        """Test that underscore in permission type is replaced with space in display"""
+        codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
+            'restricted_read', 'test', is_flag=False
+        )
+
+        # Permission name should have space instead of underscore
+        self.assertIn('restricted read', permission_name)
+
+
+class TestCleanNameAndGenerateSafeName(TestCase):
+    """Tests for helper methods clean_name and generate_safe_name"""
+
+    def test_clean_name_removes_parentheses(self):
+        """Test clean_name removes parenthetical content"""
+        result = GrievanceRightsManager.clean_name('Category (Type A)')
+        self.assertEqual(result, 'Category')
+
+    def test_clean_name_removes_multiple_parentheses(self):
+        """Test clean_name removes multiple parenthetical sections"""
+        result = GrievanceRightsManager.clean_name('Category (Type A) (Subtype B)')
+        self.assertEqual(result, 'Category')
+
+    def test_clean_name_with_no_parentheses(self):
+        """Test clean_name with no parentheses returns unchanged"""
+        result = GrievanceRightsManager.clean_name('Simple Category')
+        self.assertEqual(result, 'Simple Category')
+
+    def test_generate_safe_name_lowercase(self):
+        """Test generate_safe_name converts to lowercase"""
+        result = GrievanceRightsManager.generate_safe_name('UPPERCASE')
+        self.assertEqual(result, 'uppercase')
+
+    def test_generate_safe_name_replaces_spaces(self):
+        """Test generate_safe_name replaces spaces with underscores"""
+        result = GrievanceRightsManager.generate_safe_name('with spaces')
+        self.assertEqual(result, 'with_spaces')
+
+    def test_generate_safe_name_replaces_special_chars(self):
+        """Test generate_safe_name replaces special characters"""
+        result = GrievanceRightsManager.generate_safe_name('test-name.with!special@chars')
+        self.assertEqual(result, 'test_name_with_special_chars')
+
+    def test_generate_safe_name_removes_parentheses_first(self):
+        """Test generate_safe_name removes parenthetical content before sanitizing"""
+        result = GrievanceRightsManager.generate_safe_name('Name (With Info)')
+        self.assertEqual(result, 'name')
+
+
+class TestTruncateWithTemplate(TestCase):
+    """Tests for truncate_with_template helper method"""
+
+    def test_no_truncation_needed(self):
+        """Test that short strings are not truncated"""
+        result = GrievanceRightsManager.truncate_with_template(
+            'prefix_{variable}_suffix',
+            'short',
+            100
+        )
+        self.assertEqual(result, 'prefix_short_suffix')
+
+    def test_truncation_applied(self):
+        """Test that long strings are truncated"""
+        long_var = 'a' * 100
+        result = GrievanceRightsManager.truncate_with_template(
+            'prefix_{variable}_suffix',
+            long_var,
+            50
+        )
+
+        self.assertLessEqual(len(result), 50)
+        self.assertTrue(result.startswith('prefix_'))
+        self.assertTrue(result.endswith('_suffix'))
+
+    def test_truncation_preserves_template_structure(self):
+        """Test that truncation preserves the template prefix and suffix"""
+        long_var = 'x' * 200
+        template = 'start_{variable}_end'
+
+        result = GrievanceRightsManager.truncate_with_template(template, long_var, 30)
+
+        self.assertTrue(result.startswith('start_'))
+        self.assertTrue(result.endswith('_end'))
+
+
+class TestGenerateAutomaticRights(TestCase):
+    """Tests for GrievanceRightsManager.generate_automatic_rights()"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.ct = ContentType.objects.get_for_model(Ticket)
+
+    def tearDown(self):
+        """Clean up created test permissions"""
+        Permission.objects.filter(
+            content_type=self.ct,
+            codename__endswith='_grievance',
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).delete()
+
+    def _create_app_config(self):
+        """Create a fresh app config for testing"""
+        app_config = TicketConfig('grievance_social_protection', grievance_social_protection)
+        app_config.processed_categories = {}
+        app_config.processed_flags = {}
+        app_config.generated_rights = {}
+        return app_config
+
+    def test_creates_permissions_for_categories(self):
+        """Test that permissions are created for categories with permissions defined"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'test_cat': {
+                'permissions': ['read', 'create'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Check permissions were created
+        self.assertIn('read', app_config.processed_categories['test_cat']['generated_rights'])
+        self.assertIn('create', app_config.processed_categories['test_cat']['generated_rights'])
+
+        # Verify permission exists in database
+        read_id = app_config.processed_categories['test_cat']['generated_rights']['read']
+        perm = Permission.objects.get(id=read_id)
+        self.assertEqual(perm.codename, 'read_test_cat_grievance')
+
+    def test_creates_permissions_for_flags(self):
+        """Test that permissions are created for flags with permissions defined"""
+        app_config = self._create_app_config()
+        app_config.processed_flags = {
+            'urgent_flag': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Check permission was created
+        self.assertIn('read', app_config.processed_flags['urgent_flag']['generated_rights'])
+
+        # Verify permission exists with flag naming
+        read_id = app_config.processed_flags['urgent_flag']['generated_rights']['read']
+        perm = Permission.objects.get(id=read_id)
+        self.assertEqual(perm.codename, 'read_flag_urgent_flag_grievance')
+
+    def test_skips_categories_without_permissions(self):
+        """Test that categories without permissions don't get rights generated"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'no_perms_cat': {
+                'permissions': [],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # generated_rights should be empty
+        self.assertEqual(app_config.processed_categories['no_perms_cat']['generated_rights'], {})
+
+    def test_reuses_existing_permissions(self):
+        """Test that existing permissions are reused instead of creating duplicates"""
+        # First, create a permission manually
+        existing_perm = Permission.objects.create(
+            id=127100,
+            codename='read_existing_cat_grievance',
+            name='Can read existing_cat tickets',
+            content_type=self.ct
+        )
+
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'existing_cat': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Should reuse the existing permission ID
+        self.assertEqual(
+            app_config.processed_categories['existing_cat']['generated_rights']['read'],
+            existing_perm.id
+        )
+
+        # Verify no duplicate was created
+        count = Permission.objects.filter(codename='read_existing_cat_grievance').count()
+        self.assertEqual(count, 1)
+
+    def test_generates_all_permission_types(self):
+        """Test that all permission types can be generated"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'full_perms_cat': {
+                'permissions': ['read', 'create', 'update', 'delete', 'restricted_read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        gen_rights = app_config.processed_categories['full_perms_cat']['generated_rights']
+        self.assertEqual(len(gen_rights), 5)
+        self.assertIn('read', gen_rights)
+        self.assertIn('create', gen_rights)
+        self.assertIn('update', gen_rights)
+        self.assertIn('delete', gen_rights)
+        self.assertIn('restricted_read', gen_rights)
+
+    def test_sets_generated_rights_attribute(self):
+        """Test that generated_rights is set on the app config"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'attr_test': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Check that app_config.generated_rights is populated
+        self.assertTrue(hasattr(app_config, 'generated_rights'))
+        self.assertGreater(len(app_config.generated_rights), 0)
+
+    def test_permission_ids_follow_suffix_pattern(self):
+        """Test that generated permission IDs follow the suffix pattern"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'suffix_test': {
+                'permissions': ['read', 'create', 'update', 'delete', 'restricted_read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        gen_rights = app_config.processed_categories['suffix_test']['generated_rights']
+
+        # Verify suffixes
+        self.assertEqual(gen_rights['read'] % 10, 0)
+        self.assertEqual(gen_rights['create'] % 10, 1)
+        self.assertEqual(gen_rights['update'] % 10, 2)
+        self.assertEqual(gen_rights['delete'] % 10, 3)
+        self.assertEqual(gen_rights['restricted_read'] % 10, 4)
+
+    def test_multiple_categories_get_unique_ids(self):
+        """Test that multiple categories get unique permission IDs"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'cat_one': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            },
+            'cat_two': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        id_one = app_config.processed_categories['cat_one']['generated_rights']['read']
+        id_two = app_config.processed_categories['cat_two']['generated_rights']['read']
+
+        self.assertNotEqual(id_one, id_two)
+
+    def test_updates_default_cfg(self):
+        """Test that DEFAULT_CFG is updated with generated rights"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'cfg_test': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        # Track the key that will be generated
+        expected_key = 'gql_query_cfg_test_category_tickets_perms'
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Verify the right was added to DEFAULT_CFG
+        self.assertIn(expected_key, DEFAULT_CFG)
+
+    def test_handles_mixed_categories_and_flags(self):
+        """Test processing both categories and flags together"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'mixed_cat': {
+                'permissions': ['read', 'create'],
+                'generated_rights': {}
+            }
+        }
+        app_config.processed_flags = {
+            'mixed_flag': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Both should have generated rights
+        self.assertIn('read', app_config.processed_categories['mixed_cat']['generated_rights'])
+        self.assertIn('create', app_config.processed_categories['mixed_cat']['generated_rights'])
+        self.assertIn('read', app_config.processed_flags['mixed_flag']['generated_rights'])
+
+    def test_permissions_stored_in_database(self):
+        """Test that created permissions are actually stored in the database"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            'db_test': {
+                'permissions': ['read'],
+                'generated_rights': {}
+            }
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Query the database directly
+        perms = Permission.objects.filter(
+            content_type=self.ct,
+            codename='read_db_test_grievance'
+        )
+        self.assertEqual(perms.count(), 1)
+        self.assertEqual(perms.first().name, 'Can read db_test tickets')
+
+    def test_permissions_within_reserved_range(self):
+        """Test that all generated permissions fall within the reserved ID range"""
+        app_config = self._create_app_config()
+        app_config.processed_categories = {
+            f'range_test_{i}': {
+                'permissions': ['read', 'create'],
+                'generated_rights': {}
+            }
+            for i in range(5)
+        }
+
+        GrievanceRightsManager.generate_automatic_rights(app_config)
+
+        # Verify all generated IDs are within range
+        for cat_name, cat_info in app_config.processed_categories.items():
+            for perm_type, perm_id in cat_info['generated_rights'].items():
+                self.assertGreaterEqual(perm_id, GrievanceRightsManager.GRIEVANCE_RIGHT_BASE)
+                self.assertLessEqual(perm_id, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+
+
+class TestProcessPermissions(TestCase):
+    """Tests for GrievanceRightsManager._process_permissions()"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.ct = ContentType.objects.get_for_model(Ticket)
+
+    def tearDown(self):
+        """Clean up created test permissions"""
+        Permission.objects.filter(
+            content_type=self.ct,
+            codename__endswith='_grievance',
+            id__range=(GrievanceRightsManager.GRIEVANCE_RIGHT_BASE, GrievanceRightsManager.GRIEVANCE_RIGHT_MAX)
+        ).delete()
+
+    def test_process_category_permissions(self):
+        """Test processing permissions for a category"""
+        item_info = {
+            'permissions': ['read', 'create'],
+            'generated_rights': {}
+        }
+        existing_by_codename = {}
+        used_ids = set()
+        all_rights = {}
+
+        GrievanceRightsManager._process_permissions(
+            'test_item', item_info, False,
+            existing_by_codename, used_ids, self.ct, all_rights
+        )
+
+        # Verify generated_rights populated
+        self.assertIn('read', item_info['generated_rights'])
+        self.assertIn('create', item_info['generated_rights'])
+
+        # Verify all_rights populated
+        self.assertIn('gql_query_test_item_category_tickets_perms', all_rights)
+        self.assertIn('gql_mutation_create_test_item_category_tickets_perms', all_rights)
+
+    def test_process_flag_permissions(self):
+        """Test processing permissions for a flag"""
+        item_info = {
+            'permissions': ['read'],
+            'generated_rights': {}
+        }
+        existing_by_codename = {}
+        used_ids = set()
+        all_rights = {}
+
+        GrievanceRightsManager._process_permissions(
+            'test_flag', item_info, True,  # is_flag=True
+            existing_by_codename, used_ids, self.ct, all_rights
+        )
+
+        # Verify flag naming in all_rights
+        self.assertIn('gql_query_test_flag_flagged_tickets_perms', all_rights)
+
+    def test_skips_empty_permissions(self):
+        """Test that empty permissions list results in no processing"""
+        item_info = {
+            'permissions': [],
+            'generated_rights': {}
+        }
+        existing_by_codename = {}
+        used_ids = set()
+        all_rights = {}
+
+        GrievanceRightsManager._process_permissions(
+            'empty_test', item_info, False,
+            existing_by_codename, used_ids, self.ct, all_rights
+        )
+
+        # generated_rights should not be added since permissions is empty
+        self.assertNotIn('generated_rights', item_info)
+        self.assertEqual(len(all_rights), 0)
+
+    def test_reuses_existing_permission(self):
+        """Test that existing permissions are reused"""
+        # Create existing permission
+        existing_perm = Permission.objects.create(
+            id=127150,
+            codename='read_reuse_test_grievance',
+            name='Can read reuse_test tickets',
+            content_type=self.ct
+        )
+
+        item_info = {
+            'permissions': ['read'],
+            'generated_rights': {}
+        }
+        existing_by_codename = {'read_reuse_test_grievance': existing_perm}
+        used_ids = {127150}
+        all_rights = {}
+
+        GrievanceRightsManager._process_permissions(
+            'reuse_test', item_info, False,
+            existing_by_codename, used_ids, self.ct, all_rights
+        )
+
+        # Should use the existing permission ID
+        self.assertEqual(item_info['generated_rights']['read'], 127150)
+
+    def test_updates_used_ids(self):
+        """Test that used_ids is updated when creating new permissions"""
+        item_info = {
+            'permissions': ['read'],
+            'generated_rights': {}
+        }
+        existing_by_codename = {}
+        used_ids = set()
+        all_rights = {}
+
+        GrievanceRightsManager._process_permissions(
+            'used_ids_test', item_info, False,
+            existing_by_codename, used_ids, self.ct, all_rights
+        )
+
+        # used_ids should now contain the new ID
+        self.assertGreater(len(used_ids), 0)
+        new_id = item_info['generated_rights']['read']
+        self.assertIn(new_id, used_ids)

--- a/grievance_social_protection/tests/test_rights_manager.py
+++ b/grievance_social_protection/tests/test_rights_manager.py
@@ -241,12 +241,12 @@ class TestGeneratePermissionFields(TestCase):
     def test_hierarchical_category_name(self):
         """Test permission generation for hierarchical category names"""
         codename, permission_name, right_name = GrievanceRightsManager._generate_permission_fields(
-            'read', 'parent|child', is_flag=False
+            'read', 'parent > child', is_flag=False
         )
 
-        # Pipe character should become underscore in codename, space in label
+        # Separator should become underscore in codename, kept readable in label
         self.assertEqual(codename, 'read_parent_child_grievance')
-        self.assertEqual(permission_name, 'Can read parent child tickets')
+        self.assertEqual(permission_name, 'Can read parent > child tickets')
 
     def test_codename_truncation_for_long_names(self):
         """Test that long names are truncated to fit Django's 100 char limit"""

--- a/grievance_social_protection/tests/test_rights_manager.py
+++ b/grievance_social_protection/tests/test_rights_manager.py
@@ -6,15 +6,13 @@ This module provides comprehensive test coverage for:
 - _get_next_available_id(): ID generation with suffix pattern
 - _generate_permission_fields(): Codename and permission name generation
 """
-from unittest.mock import MagicMock, patch
-
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.rights import GrievanceRightsManager
-from grievance_social_protection.apps import TicketConfig, DEFAULT_CFG
+from grievance_social_protection.apps import TicketConfig
 import grievance_social_protection
 
 

--- a/grievance_social_protection/tests/test_rights_manager.py
+++ b/grievance_social_protection/tests/test_rights_manager.py
@@ -246,9 +246,9 @@ class TestGeneratePermissionFields(TestCase):
             'read', 'parent|child', is_flag=False
         )
 
-        # Pipe character should become underscore
+        # Pipe character should become underscore in codename, space in label
         self.assertEqual(codename, 'read_parent_child_grievance')
-        self.assertEqual(permission_name, 'Can read parent|child tickets')
+        self.assertEqual(permission_name, 'Can read parent child tickets')
 
     def test_codename_truncation_for_long_names(self):
         """Test that long names are truncated to fit Django's 100 char limit"""

--- a/grievance_social_protection/tests/test_ticket_filterset.py
+++ b/grievance_social_protection/tests/test_ticket_filterset.py
@@ -1,0 +1,280 @@
+"""
+Tests for TicketFilterSet — verifies that filter-level field restrictions
+prevent information inference attacks by users with restricted_read access.
+"""
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from core.test_helpers import create_test_interactive_user
+
+from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.gql_queries import TicketFilterSet, _ALWAYS_FILTERABLE
+from grievance_social_protection.models import Ticket
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, get_rights,
+)
+
+
+class TicketFilterSetRestrictedFieldsTest(TestCase):
+    """Test _get_restricted_fields for different access levels."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_restricted = create_test_interactive_user(
+            username='fs_restricted', roles=[1]
+        )
+        cls.user_full = create_test_interactive_user(
+            username='fs_full', roles=[1]
+        )
+        cls.user_no_access = create_test_interactive_user(
+            username='fs_no_access', roles=[1]
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._saved_cats = TicketConfig.processed_categories
+        self._saved_flags = TicketConfig.processed_flags
+        self._setup_config()
+
+    def tearDown(self):
+        TicketConfig.processed_categories = self._saved_cats
+        TicketConfig.processed_flags = self._saved_flags
+        super().tearDown()
+
+    def _setup_config(self):
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'restricted_cat',
+                    'permissions': ['restricted_read', 'read'],
+                    'visible_fields': ['id', 'status', 'category', 'priority'],
+                },
+                'open_cat',
+            ],
+            'grievance_flags': [],
+        }
+        setup_grievance_config(cfg)
+
+        cat_rights = get_rights('processed_categories', 'restricted_cat')
+
+        if cat_rights.get('restricted_read'):
+            assign_rights_to_user(
+                self.user_restricted,
+                [127000, cat_rights['restricted_read']],
+                role_name='FSRestrictedRole',
+            )
+
+        if cat_rights.get('read'):
+            assign_rights_to_user(
+                self.user_full,
+                [127000, cat_rights['read']],
+                role_name='FSFullRole',
+            )
+
+    # ── _get_restricted_fields tests ─────────────────────────────
+
+    def test_restricted_user_has_restricted_fields(self):
+        """Restricted user should have fields outside visible_fields blocked."""
+        restricted = TicketFilterSet._get_restricted_fields(self.user_restricted)
+        # 'description' is NOT in visible_fields so should be restricted
+        self.assertIn('description', restricted)
+        self.assertIn('resolution', restricted)
+        self.assertIn('channel', restricted)
+        self.assertIn('title', restricted)
+
+    def test_restricted_user_allows_visible_fields(self):
+        """Restricted user should NOT have visible_fields blocked."""
+        restricted = TicketFilterSet._get_restricted_fields(self.user_restricted)
+        self.assertNotIn('status', restricted)
+        self.assertNotIn('category', restricted)
+        self.assertNotIn('priority', restricted)
+
+    def test_full_access_user_no_restricted_fields(self):
+        """User with read access should have no restricted fields."""
+        restricted = TicketFilterSet._get_restricted_fields(self.user_full)
+        self.assertEqual(restricted, set())
+
+    def test_no_access_user_no_restricted_fields(self):
+        """User with no grievance rights returns empty set (queryset filtering
+        handles access denial; filter restriction is an additional guard)."""
+        restricted = TicketFilterSet._get_restricted_fields(self.user_no_access)
+        # get_visible_fields returns [] for no access, which is falsy →
+        # the `if visible_fields is not None and visible_fields:` guard skips it
+        self.assertEqual(restricted, set())
+
+    def test_anonymous_user_all_fields_restricted(self):
+        """Anonymous user has all filterable fields restricted (defense-in-depth)."""
+        anon = MagicMock()
+        anon.is_anonymous = True
+        restricted = TicketFilterSet._get_restricted_fields(anon)
+        expected = set(TicketFilterSet.Meta.fields.keys()) - _ALWAYS_FILTERABLE
+        self.assertEqual(restricted, expected)
+
+    def test_none_user_all_fields_restricted(self):
+        """None user has all filterable fields restricted (defense-in-depth)."""
+        restricted = TicketFilterSet._get_restricted_fields(None)
+        expected = set(TicketFilterSet.Meta.fields.keys()) - _ALWAYS_FILTERABLE
+        self.assertEqual(restricted, expected)
+
+    def test_always_filterable_not_restricted(self):
+        """Fields in _ALWAYS_FILTERABLE are never in the restricted set."""
+        restricted = TicketFilterSet._get_restricted_fields(self.user_restricted)
+        for field in _ALWAYS_FILTERABLE:
+            self.assertNotIn(field, restricted)
+
+    def test_no_config_returns_empty(self):
+        """When no categories are configured, nothing is restricted."""
+        TicketConfig.processed_categories = {}
+        restricted = TicketFilterSet._get_restricted_fields(self.user_restricted)
+        self.assertEqual(restricted, set())
+
+
+class TicketFilterSetFilterQuerysetTest(TestCase):
+    """Test that filter_queryset actually skips restricted filters."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_restricted = create_test_interactive_user(
+            username='fq_restricted', roles=[1]
+        )
+        cls.user_full = create_test_interactive_user(
+            username='fq_full', roles=[1]
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._saved_cats = TicketConfig.processed_categories
+        self._saved_flags = TicketConfig.processed_flags
+        self._setup_config()
+        self._create_tickets()
+
+    def tearDown(self):
+        Ticket.objects.filter(code__startswith='FSTEST').delete()
+        TicketConfig.processed_categories = self._saved_cats
+        TicketConfig.processed_flags = self._saved_flags
+        super().tearDown()
+
+    def _setup_config(self):
+        cfg = {
+            'grievance_types': [
+                {
+                    'name': 'filter_cat',
+                    'permissions': ['restricted_read', 'read'],
+                    'visible_fields': ['id', 'status', 'category', 'priority'],
+                },
+            ],
+            'grievance_flags': [],
+        }
+        setup_grievance_config(cfg)
+
+        cat_rights = get_rights('processed_categories', 'filter_cat')
+
+        if cat_rights.get('restricted_read'):
+            assign_rights_to_user(
+                self.user_restricted,
+                [127000, cat_rights['restricted_read']],
+                role_name='FQRestrictedRole',
+            )
+
+        if cat_rights.get('read'):
+            assign_rights_to_user(
+                self.user_full,
+                [127000, cat_rights['read']],
+                role_name='FQFullRole',
+            )
+
+    def _create_tickets(self):
+        self.ticket_match = Ticket(
+            code='FSTEST001',
+            title='Sensitive Title',
+            description='secret information',
+            category='filter_cat',
+            status='OPEN',
+            priority='High',
+        )
+        self.ticket_match.save(user=self.user_full)
+
+        self.ticket_other = Ticket(
+            code='FSTEST002',
+            title='Other Title',
+            description='other info',
+            category='filter_cat',
+            status='OPEN',
+            priority='Low',
+        )
+        self.ticket_other.save(user=self.user_full)
+
+    def _build_filterset(self, user, data):
+        """Build a TicketFilterSet with a mock request carrying the given user."""
+        request = MagicMock()
+        request.user = user
+        qs = Ticket.objects.filter(code__startswith='FSTEST')
+        fs = TicketFilterSet(data=data, queryset=qs, request=request)
+        # Trigger form validation so cleaned_data is populated
+        fs.form.is_valid()
+        return fs
+
+    def test_full_user_can_filter_on_description(self):
+        """Full access user can filter on description and get matching results."""
+        fs = self._build_filterset(
+            self.user_full, {'description__icontains': 'secret'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        self.assertIn('FSTEST001', codes)
+        self.assertNotIn('FSTEST002', codes)
+
+    def test_restricted_user_cannot_filter_on_description(self):
+        """Restricted user's description filter is silently skipped."""
+        fs = self._build_filterset(
+            self.user_restricted, {'description__icontains': 'secret'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        # Both tickets should appear because the filter was skipped
+        self.assertIn('FSTEST001', codes)
+        self.assertIn('FSTEST002', codes)
+
+    def test_restricted_user_can_filter_on_status(self):
+        """Restricted user can still filter on visible fields like status."""
+        fs = self._build_filterset(
+            self.user_restricted, {'status': 'OPEN'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        self.assertIn('FSTEST001', codes)
+        self.assertIn('FSTEST002', codes)
+
+    def test_restricted_user_can_filter_on_priority(self):
+        """Restricted user can filter on priority (in visible_fields)."""
+        fs = self._build_filterset(
+            self.user_restricted, {'priority': 'High'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        self.assertIn('FSTEST001', codes)
+        self.assertNotIn('FSTEST002', codes)
+
+    def test_restricted_user_title_filter_skipped(self):
+        """title is not in visible_fields → filter should be skipped."""
+        fs = self._build_filterset(
+            self.user_restricted, {'title__icontains': 'Sensitive'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        # Filter skipped → both tickets returned
+        self.assertIn('FSTEST001', codes)
+        self.assertIn('FSTEST002', codes)
+
+    def test_full_user_title_filter_works(self):
+        """Full access user CAN filter on title."""
+        fs = self._build_filterset(
+            self.user_full, {'title__icontains': 'Sensitive'}
+        )
+        result = fs.filter_queryset(fs.queryset)
+        codes = list(result.values_list('code', flat=True))
+        self.assertIn('FSTEST001', codes)
+        self.assertNotIn('FSTEST002', codes)

--- a/grievance_social_protection/tests/test_ticket_filterset.py
+++ b/grievance_social_protection/tests/test_ticket_filterset.py
@@ -12,7 +12,8 @@ from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.gql_queries import TicketFilterSet, _ALWAYS_FILTERABLE
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, get_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, get_rights,
 )
 
 
@@ -34,13 +35,10 @@ class TicketFilterSetRestrictedFieldsTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self._saved_cats = TicketConfig.processed_categories
-        self._saved_flags = TicketConfig.processed_flags
-        self._setup_config()
+        self._snapshot = self._setup_config()
 
     def tearDown(self):
-        TicketConfig.processed_categories = self._saved_cats
-        TicketConfig.processed_flags = self._saved_flags
+        restore_grievance_config(self._snapshot)
         super().tearDown()
 
     def _setup_config(self):
@@ -55,7 +53,7 @@ class TicketFilterSetRestrictedFieldsTest(TestCase):
             ],
             'grievance_flags': [],
         }
-        setup_grievance_config(cfg)
+        snapshot = setup_grievance_config(cfg)
 
         cat_rights = get_rights('processed_categories', 'restricted_cat')
 
@@ -72,6 +70,8 @@ class TicketFilterSetRestrictedFieldsTest(TestCase):
                 [127000, cat_rights['read']],
                 role_name='FSFullRole',
             )
+
+        return snapshot
 
     # ── _get_restricted_fields tests ─────────────────────────────
 
@@ -146,15 +146,12 @@ class TicketFilterSetFilterQuerysetTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self._saved_cats = TicketConfig.processed_categories
-        self._saved_flags = TicketConfig.processed_flags
-        self._setup_config()
+        self._snapshot = self._setup_config()
         self._create_tickets()
 
     def tearDown(self):
         Ticket.objects.filter(code__startswith='FSTEST').delete()
-        TicketConfig.processed_categories = self._saved_cats
-        TicketConfig.processed_flags = self._saved_flags
+        restore_grievance_config(self._snapshot)
         super().tearDown()
 
     def _setup_config(self):
@@ -168,7 +165,7 @@ class TicketFilterSetFilterQuerysetTest(TestCase):
             ],
             'grievance_flags': [],
         }
-        setup_grievance_config(cfg)
+        snapshot = setup_grievance_config(cfg)
 
         cat_rights = get_rights('processed_categories', 'filter_cat')
 
@@ -185,6 +182,8 @@ class TicketFilterSetFilterQuerysetTest(TestCase):
                 [127000, cat_rights['read']],
                 role_name='FQFullRole',
             )
+
+        return snapshot
 
     def _create_tickets(self):
         self.ticket_match = Ticket(

--- a/grievance_social_protection/tests/test_ticket_query_filtering.py
+++ b/grievance_social_protection/tests/test_ticket_query_filtering.py
@@ -1,0 +1,255 @@
+from django.test import TestCase
+
+from core.test_helpers import create_test_interactive_user
+from grievance_social_protection.access_control import GrievanceAccessControl
+from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.models import Ticket
+
+
+class TicketQueryFilteringTest(TestCase):
+    """Test ticket queryset filtering based on permissions"""
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_test_config()
+        cls._create_test_users()
+        cls._create_test_tickets()
+    
+    def setUp(self):
+        # Reset config for each test
+        self._setup_test_config()
+    
+    @classmethod
+    def _setup_test_config(cls):
+        """Set up test configuration"""
+        config = {
+            'grievance_types': [
+                'public_category',
+                {
+                    'name': 'restricted_category',
+                    'permissions': ['127002', '127003']
+                },
+                {
+                    'name': 'sensitive_category',
+                    'permissions': ['127006'],
+                    'default_flags': ['sensitive']
+                }
+            ],
+            'grievance_flags': [
+                'urgent',
+                {
+                    'name': 'sensitive',
+                    'permissions': ['127004', '127005']
+                },
+                {
+                    'name': 'confidential',
+                    'permissions': ['127006']
+                }
+            ]
+        }
+        
+        # Process configuration
+        TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__process_unified_flags(config)
+        TicketConfig._TicketConfig__load_config(config)
+    
+    @classmethod
+    def _create_test_users(cls):
+        """Create test users with different permission levels"""
+        # User with all permissions
+        cls.user_all_perms = create_test_interactive_user(username='user_all_perms', roles=[7])  # Admin role
+        
+        # User with limited permissions (only view tickets)
+        cls.user_limited = create_test_interactive_user(username='user_limited', roles=[1])  # Basic role
+        # Manually add specific permissions
+        cls._add_permissions_to_user(cls.user_limited, ['127000', '127001'])  # View and create tickets
+        
+        # User with mixed permissions
+        cls.user_mixed = create_test_interactive_user(username='user_mixed', roles=[1])  # Basic role
+        cls._add_permissions_to_user(cls.user_mixed, ['127000', '127004'])  # View tickets and comments
+    
+    @classmethod
+    def _add_permissions_to_user(cls, user, permission_codes):
+        """Add specific permissions to a user"""
+        if hasattr(user, 'i_user') and user.i_user:
+            # Add to the user's rights through their role
+            from core.models import Role, RoleRight, UserRole
+            
+            # Create a custom role for this user
+            role = Role.objects.create(
+                name=f"TestRole_{user.username}",
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            
+            # Add rights to the role
+            for perm_code in permission_codes:
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=int(perm_code),
+                    audit_user_id=-1
+                )
+            
+            # Assign role to user
+            UserRole.objects.create(
+                user=user.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+    
+    @classmethod
+    def _create_test_tickets(cls):
+        """Create test tickets"""
+        # Create tickets with user for history tracking
+        cls.tickets = {}
+        
+        ticket = Ticket(
+            title='Public ticket',
+            category='public_category',
+            flags='urgent',
+            resolution='5,0'
+        )
+        ticket.save(user=cls.user_all_perms)
+        cls.tickets['public'] = ticket
+        
+        ticket = Ticket(
+            title='Restricted ticket',
+            category='restricted_category',
+            flags='urgent',
+            resolution='5,0'
+        )
+        ticket.save(user=cls.user_all_perms)
+        cls.tickets['restricted'] = ticket
+        
+        ticket = Ticket(
+            title='Sensitive ticket',
+            category='sensitive_category',
+            flags='sensitive',
+            resolution='5,0'
+        )
+        ticket.save(user=cls.user_all_perms)
+        cls.tickets['sensitive'] = ticket
+        
+        ticket = Ticket(
+            title='Public with confidential flag',
+            category='public_category',
+            flags='confidential',
+            resolution='5,0'
+        )
+        ticket.save(user=cls.user_all_perms)
+        cls.tickets['confidential'] = ticket
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test data"""
+        # Get all ticket IDs before cleanup
+        ticket_ids = [t.id for t in cls.tickets.values()]
+        # Delete using a single query
+        Ticket.objects.filter(id__in=ticket_ids).delete()
+        super().tearDownClass()
+    
+    def test_filter_all_permissions(self):
+        """Test filtering with all permissions"""
+        # Admin user should see all tickets
+        queryset = Ticket.objects.all()
+        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_all_perms)
+        
+        # Should see all tickets
+        ticket_ids = list(filtered.values_list('id', flat=True))
+        for ticket in self.tickets.values():
+            self.assertIn(ticket.id, ticket_ids)
+    
+    def test_filter_limited_permissions(self):
+        """Test filtering with limited permissions"""
+        # User with only basic permissions
+        queryset = Ticket.objects.all()
+        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+        
+        ticket_ids = list(filtered.values_list('id', flat=True))
+        
+        # Should only see public category with urgent flag (no restricted permissions)
+        self.assertIn(self.tickets['public'].id, ticket_ids)
+        # Should NOT see these due to category/flag restrictions
+        self.assertNotIn(self.tickets['restricted'].id, ticket_ids)  # Needs 127002/127003
+        self.assertNotIn(self.tickets['sensitive'].id, ticket_ids)   # Needs 127006
+        self.assertNotIn(self.tickets['confidential'].id, ticket_ids)  # Needs 127006 for flag
+    
+    def test_filter_no_config(self):
+        """Test filtering when no config exists"""
+        # Save and clear config
+        original_cats = TicketConfig.processed_categories
+        original_flags = TicketConfig.processed_flags
+        TicketConfig.processed_categories = {}
+        TicketConfig.processed_flags = {}
+        
+        try:
+            queryset = Ticket.objects.all()
+            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+            # Should return all when no config
+            self.assertEqual(queryset.count(), filtered.count())
+        finally:
+            # Restore config
+            TicketConfig.processed_categories = original_cats
+            TicketConfig.processed_flags = original_flags
+    
+    def test_filter_mixed_flags(self):
+        """Test filtering with mixed flag permissions"""
+        # Create ticket with multiple flags
+        mixed_ticket = Ticket(
+            title='Mixed flags',
+            category='public_category',
+            flags='urgent sensitive',
+            resolution='5,0'
+        )
+        mixed_ticket.save(user=self.user_mixed)
+        
+        try:
+            queryset = Ticket.objects.all()
+            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_mixed)
+            
+            ticket_ids = list(filtered.values_list('id', flat=True))
+            # User has 127004 which allows sensitive flag
+            self.assertIn(mixed_ticket.id, ticket_ids)
+            # But not confidential flag (needs 127006)
+            self.assertNotIn(self.tickets['confidential'].id, ticket_ids)
+        finally:
+            mixed_ticket.delete(username=self.user_mixed.username)
+    
+    def test_filter_hierarchical_categories(self):
+        """Test filtering with hierarchical categories"""
+        # Add parent-child categories
+        config = {
+            'grievance_types': [
+                'public_category',
+                {
+                    'name': 'parent',
+                    'permissions': ['127002'],
+                    'children': ['child1', 'child2']
+                }
+            ],
+            'grievance_flags': ['urgent']
+        }
+        
+        # Process config
+        TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__load_config(config)
+        
+        # Create hierarchical tickets
+        parent_ticket = Ticket(title='Parent', category='parent', resolution='5,0')
+        parent_ticket.save(user=self.user_limited)
+        child_ticket = Ticket(title='Child', category='parent|child1', resolution='5,0')
+        child_ticket.save(user=self.user_limited)
+        
+        try:
+            queryset = Ticket.objects.all()
+            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+            
+            ticket_ids = list(filtered.values_list('id', flat=True))
+            # User doesn't have 127002, shouldn't see parent or child
+            self.assertNotIn(parent_ticket.id, ticket_ids)
+            self.assertNotIn(child_ticket.id, ticket_ids)
+        finally:
+            parent_ticket.delete(username=self.user_limited.username)
+            child_ticket.delete(username=self.user_limited.username)

--- a/grievance_social_protection/tests/test_ticket_query_filtering.py
+++ b/grievance_social_protection/tests/test_ticket_query_filtering.py
@@ -3,26 +3,29 @@ from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
 from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, get_rights, collect_all_rights,
+)
 
 
 class TicketQueryFilteringTest(TestCase):
     """Test ticket queryset filtering based on permissions"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._setup_test_config()
         cls._create_test_users()
         cls._create_test_tickets()
-    
+
     def setUp(self):
         # Reset config for each test
         self._setup_test_config()
-    
+
     @classmethod
     def _setup_test_config(cls):
         """Set up test configuration"""
-        config = {
+        cfg = {
             'grievance_types': [
                 'public_category',
                 {
@@ -47,88 +50,33 @@ class TicketQueryFilteringTest(TestCase):
                 }
             ]
         }
-        
-        # Process configuration
-        TicketConfig._TicketConfig__process_unified_categories(config)
-        TicketConfig._TicketConfig__process_unified_flags(config)
-        TicketConfig._TicketConfig__load_config(config)
-        
-        # Generate rights for the configuration
-        cls._generate_test_rights()
-    
-    @classmethod
-    def _generate_test_rights(cls):
-        """Use the actual GrievanceRightsManager to generate rights"""
-        from grievance_social_protection.rights import GrievanceRightsManager
-        
-        # Generate rights using the real rights manager
-        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
-    
+        setup_grievance_config(cfg)
+
     @classmethod
     def _create_test_users(cls):
         """Create test users with different permission levels"""
         # User with all permissions
-        cls.user_all_perms = create_test_interactive_user(username='user_all_perms', roles=[7])  # Admin role
-        # Add all generated grievance rights to admin user
-        all_generated_rights = ['127000']  # Base query permission
-        for cat_info in TicketConfig.processed_categories.values():
-            if cat_info.get('generated_rights'):
-                all_generated_rights.extend(str(right_id) for right_id in cat_info['generated_rights'].values())
-        for flag_info in TicketConfig.processed_flags.values():
-            if flag_info.get('generated_rights'):
-                all_generated_rights.extend(str(right_id) for right_id in flag_info['generated_rights'].values())
-        cls._add_permissions_to_user(cls.user_all_perms, all_generated_rights)
-        
+        cls.user_all_perms = create_test_interactive_user(username='user_all_perms', roles=[7])
+        all_right_ids = [127000] + list(collect_all_rights())
+        assign_rights_to_user(cls.user_all_perms, all_right_ids, 'QFAllPermsRole')
+
         # User with limited permissions (only basic query permission)
-        cls.user_limited = create_test_interactive_user(username='user_limited', roles=[1])  # Basic role
-        # Only add base query permission - no grievance-specific rights
-        cls._add_permissions_to_user(cls.user_limited, ['127000'])  # Base query permission only
-        
+        cls.user_limited = create_test_interactive_user(username='user_limited', roles=[1])
+        assign_rights_to_user(cls.user_limited, [127000], 'QFLimitedRole')
+
         # User with mixed permissions - can read sensitive flag
-        cls.user_mixed = create_test_interactive_user(username='user_mixed', roles=[1])  # Basic role
-        # Add base query and sensitive flag read permission
-        sensitive_rights = TicketConfig.processed_flags.get('sensitive', {}).get('generated_rights', {})
-        perms = ['127000']  # Base query permission
+        cls.user_mixed = create_test_interactive_user(username='user_mixed', roles=[1])
+        sensitive_rights = get_rights('processed_flags', 'sensitive')
+        mixed_ids = [127000]
         if sensitive_rights.get('read'):
-            perms.append(str(sensitive_rights['read']))
-        cls._add_permissions_to_user(cls.user_mixed, perms)
-    
-    @classmethod
-    def _add_permissions_to_user(cls, user, permission_codes):
-        """Add specific permissions to a user"""
-        if hasattr(user, 'i_user') and user.i_user:
-            # Add to the user's rights through their role
-            from core.models import Role, RoleRight, UserRole
-            
-            # Create a custom role for this user
-            role = Role.objects.create(
-                name=f"TestRole_{user.username}",
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            
-            # Add rights to the role
-            for perm_code in permission_codes:
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=int(perm_code),
-                    audit_user_id=-1
-                )
-            
-            # Assign role to user
-            UserRole.objects.create(
-                user=user.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-    
+            mixed_ids.append(sensitive_rights['read'])
+        assign_rights_to_user(cls.user_mixed, mixed_ids, 'QFMixedRole')
+
     @classmethod
     def _create_test_tickets(cls):
         """Create test tickets"""
-        # Create tickets with user for history tracking
         cls.tickets = {}
-        
+
         ticket = Ticket(
             title='Public ticket',
             category='public_category',
@@ -137,7 +85,7 @@ class TicketQueryFilteringTest(TestCase):
         )
         ticket.save(user=cls.user_all_perms)
         cls.tickets['public'] = ticket
-        
+
         ticket = Ticket(
             title='Restricted ticket',
             category='restricted_category',
@@ -146,7 +94,7 @@ class TicketQueryFilteringTest(TestCase):
         )
         ticket.save(user=cls.user_all_perms)
         cls.tickets['restricted'] = ticket
-        
+
         ticket = Ticket(
             title='Sensitive ticket',
             category='sensitive_category',
@@ -155,7 +103,7 @@ class TicketQueryFilteringTest(TestCase):
         )
         ticket.save(user=cls.user_all_perms)
         cls.tickets['sensitive'] = ticket
-        
+
         ticket = Ticket(
             title='Public with confidential flag',
             category='public_category',
@@ -164,68 +112,56 @@ class TicketQueryFilteringTest(TestCase):
         )
         ticket.save(user=cls.user_all_perms)
         cls.tickets['confidential'] = ticket
-    
+
     @classmethod
     def tearDownClass(cls):
         """Clean up test data"""
-        # Get all ticket IDs before cleanup
         ticket_ids = [t.id for t in cls.tickets.values()]
-        # Delete using a single query
         Ticket.objects.filter(id__in=ticket_ids).delete()
         super().tearDownClass()
-    
+
     def test_filter_all_permissions(self):
         """Test filtering with all permissions"""
-        # Admin user should see all tickets
         test_ticket_ids = [t.id for t in self.tickets.values()]
         queryset = Ticket.objects.filter(id__in=test_ticket_ids)
-        
+
         filtered = Ticket.get_queryset(queryset, self.user_all_perms)
-        
-        # Should see all 4 test tickets
+
         ticket_ids = list(filtered.values_list('id', flat=True))
-        
-        # Check each ticket individually
+
         for name, ticket in self.tickets.items():
-            self.assertIn(ticket.id, ticket_ids, 
+            self.assertIn(ticket.id, ticket_ids,
                          f"Admin user should see '{name}' ticket (category={ticket.category}, flags={ticket.flags})")
-    
+
     def test_filter_limited_permissions(self):
         """Test filtering with limited permissions"""
-        # User with only basic permissions
         queryset = Ticket.objects.all()
         filtered = Ticket.get_queryset(queryset, self.user_limited)
-        
+
         ticket_ids = list(filtered.values_list('id', flat=True))
-        
-        # Should only see public category tickets (no restricted permissions)
+
         self.assertIn(self.tickets['public'].id, ticket_ids)
-        # Should NOT see these due to category/flag restrictions
-        self.assertNotIn(self.tickets['restricted'].id, ticket_ids)  # Needs read permission for restricted_category
-        self.assertNotIn(self.tickets['sensitive'].id, ticket_ids)   # Needs read permission for sensitive_category
-        self.assertNotIn(self.tickets['confidential'].id, ticket_ids)  # Needs read permission for confidential flag
-    
+        self.assertNotIn(self.tickets['restricted'].id, ticket_ids)
+        self.assertNotIn(self.tickets['sensitive'].id, ticket_ids)
+        self.assertNotIn(self.tickets['confidential'].id, ticket_ids)
+
     def test_filter_no_config(self):
         """Test filtering when no config exists"""
-        # Save and clear config
         original_cats = TicketConfig.processed_categories
         original_flags = TicketConfig.processed_flags
         TicketConfig.processed_categories = {}
         TicketConfig.processed_flags = {}
-        
+
         try:
             queryset = Ticket.objects.all()
             filtered = Ticket.get_queryset(queryset, self.user_limited)
-            # Should return all when no config
             self.assertEqual(queryset.count(), filtered.count())
         finally:
-            # Restore config
             TicketConfig.processed_categories = original_cats
             TicketConfig.processed_flags = original_flags
-    
+
     def test_filter_mixed_flags(self):
         """Test filtering with mixed flag permissions"""
-        # Create ticket with multiple flags
         mixed_ticket = Ticket(
             title='Mixed flags',
             category='public_category',
@@ -233,23 +169,20 @@ class TicketQueryFilteringTest(TestCase):
             resolution='5,0'
         )
         mixed_ticket.save(user=self.user_mixed)
-        
+
         try:
             queryset = Ticket.objects.all()
             filtered = Ticket.get_queryset(queryset, self.user_mixed)
-            
+
             ticket_ids = list(filtered.values_list('id', flat=True))
-            # User has read permission for sensitive flag
             self.assertIn(mixed_ticket.id, ticket_ids)
-            # But not for confidential flag
             self.assertNotIn(self.tickets['confidential'].id, ticket_ids)
         finally:
             mixed_ticket.delete(username=self.user_mixed.username)
-    
+
     def test_filter_hierarchical_categories(self):
         """Test filtering with hierarchical categories"""
-        # Add parent-child categories
-        config = {
+        cfg = {
             'grievance_types': [
                 'public_category',
                 {
@@ -260,25 +193,17 @@ class TicketQueryFilteringTest(TestCase):
             ],
             'grievance_flags': ['urgent']
         }
-        
-        # Process config
-        TicketConfig._TicketConfig__process_unified_categories(config)
-        TicketConfig._TicketConfig__process_unified_flags(config)
-        TicketConfig._TicketConfig__load_config(config)
-        
-        # Generate rights for the new configuration
-        self._generate_test_rights()
-        
-        # Create hierarchical tickets
+        setup_grievance_config(cfg)
+
         parent_ticket = Ticket(title='Parent', category='parent', resolution='5,0')
         parent_ticket.save(user=self.user_limited)
         child_ticket = Ticket(title='Child', category='parent|child1', resolution='5,0')
         child_ticket.save(user=self.user_limited)
-        
+
         try:
             queryset = Ticket.objects.all()
             filtered = Ticket.get_queryset(queryset, self.user_limited)
-            
+
             ticket_ids = list(filtered.values_list('id', flat=True))
             self.assertNotIn(parent_ticket.id, ticket_ids)
             self.assertNotIn(child_ticket.id, ticket_ids)

--- a/grievance_social_protection/tests/test_ticket_query_filtering.py
+++ b/grievance_social_protection/tests/test_ticket_query_filtering.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from core.test_helpers import create_test_interactive_user
-from grievance_social_protection.access_control import GrievanceAccessControl
 from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
 
@@ -28,11 +27,11 @@ class TicketQueryFilteringTest(TestCase):
                 'public_category',
                 {
                     'name': 'restricted_category',
-                    'permissions': ['127002', '127003']
+                    'permissions': ['restricted_read', 'read', 'create']
                 },
                 {
                     'name': 'sensitive_category',
-                    'permissions': ['127006'],
+                    'permissions': ['restricted_read', 'read'],
                     'default_flags': ['sensitive']
                 }
             ],
@@ -40,11 +39,11 @@ class TicketQueryFilteringTest(TestCase):
                 'urgent',
                 {
                     'name': 'sensitive',
-                    'permissions': ['127004', '127005']
+                    'permissions': ['restricted_read', 'read', 'create']
                 },
                 {
                     'name': 'confidential',
-                    'permissions': ['127006']
+                    'permissions': ['restricted_read', 'read']
                 }
             ]
         }
@@ -53,21 +52,46 @@ class TicketQueryFilteringTest(TestCase):
         TicketConfig._TicketConfig__process_unified_categories(config)
         TicketConfig._TicketConfig__process_unified_flags(config)
         TicketConfig._TicketConfig__load_config(config)
+        
+        # Generate rights for the configuration
+        cls._generate_test_rights()
+    
+    @classmethod
+    def _generate_test_rights(cls):
+        """Use the actual GrievanceRightsManager to generate rights"""
+        from grievance_social_protection.rights import GrievanceRightsManager
+        
+        # Generate rights using the real rights manager
+        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
     
     @classmethod
     def _create_test_users(cls):
         """Create test users with different permission levels"""
         # User with all permissions
         cls.user_all_perms = create_test_interactive_user(username='user_all_perms', roles=[7])  # Admin role
+        # Add all generated grievance rights to admin user
+        all_generated_rights = ['127000']  # Base query permission
+        for cat_info in TicketConfig.processed_categories.values():
+            if cat_info.get('generated_rights'):
+                all_generated_rights.extend(str(right_id) for right_id in cat_info['generated_rights'].values())
+        for flag_info in TicketConfig.processed_flags.values():
+            if flag_info.get('generated_rights'):
+                all_generated_rights.extend(str(right_id) for right_id in flag_info['generated_rights'].values())
+        cls._add_permissions_to_user(cls.user_all_perms, all_generated_rights)
         
-        # User with limited permissions (only view tickets)
+        # User with limited permissions (only basic query permission)
         cls.user_limited = create_test_interactive_user(username='user_limited', roles=[1])  # Basic role
-        # Manually add specific permissions
-        cls._add_permissions_to_user(cls.user_limited, ['127000', '127001'])  # View and create tickets
+        # Only add base query permission - no grievance-specific rights
+        cls._add_permissions_to_user(cls.user_limited, ['127000'])  # Base query permission only
         
-        # User with mixed permissions
+        # User with mixed permissions - can read sensitive flag
         cls.user_mixed = create_test_interactive_user(username='user_mixed', roles=[1])  # Basic role
-        cls._add_permissions_to_user(cls.user_mixed, ['127000', '127004'])  # View tickets and comments
+        # Add base query and sensitive flag read permission
+        sensitive_rights = TicketConfig.processed_flags.get('sensitive', {}).get('generated_rights', {})
+        perms = ['127000']  # Base query permission
+        if sensitive_rights.get('read'):
+            perms.append(str(sensitive_rights['read']))
+        cls._add_permissions_to_user(cls.user_mixed, perms)
     
     @classmethod
     def _add_permissions_to_user(cls, user, permission_codes):
@@ -153,28 +177,33 @@ class TicketQueryFilteringTest(TestCase):
     def test_filter_all_permissions(self):
         """Test filtering with all permissions"""
         # Admin user should see all tickets
-        queryset = Ticket.objects.all()
-        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_all_perms)
+        test_ticket_ids = [t.id for t in self.tickets.values()]
+        queryset = Ticket.objects.filter(id__in=test_ticket_ids)
         
-        # Should see all tickets
+        filtered = Ticket.get_queryset(queryset, self.user_all_perms)
+        
+        # Should see all 4 test tickets
         ticket_ids = list(filtered.values_list('id', flat=True))
-        for ticket in self.tickets.values():
-            self.assertIn(ticket.id, ticket_ids)
+        
+        # Check each ticket individually
+        for name, ticket in self.tickets.items():
+            self.assertIn(ticket.id, ticket_ids, 
+                         f"Admin user should see '{name}' ticket (category={ticket.category}, flags={ticket.flags})")
     
     def test_filter_limited_permissions(self):
         """Test filtering with limited permissions"""
         # User with only basic permissions
         queryset = Ticket.objects.all()
-        filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+        filtered = Ticket.get_queryset(queryset, self.user_limited)
         
         ticket_ids = list(filtered.values_list('id', flat=True))
         
-        # Should only see public category with urgent flag (no restricted permissions)
+        # Should only see public category tickets (no restricted permissions)
         self.assertIn(self.tickets['public'].id, ticket_ids)
         # Should NOT see these due to category/flag restrictions
-        self.assertNotIn(self.tickets['restricted'].id, ticket_ids)  # Needs 127002/127003
-        self.assertNotIn(self.tickets['sensitive'].id, ticket_ids)   # Needs 127006
-        self.assertNotIn(self.tickets['confidential'].id, ticket_ids)  # Needs 127006 for flag
+        self.assertNotIn(self.tickets['restricted'].id, ticket_ids)  # Needs read permission for restricted_category
+        self.assertNotIn(self.tickets['sensitive'].id, ticket_ids)   # Needs read permission for sensitive_category
+        self.assertNotIn(self.tickets['confidential'].id, ticket_ids)  # Needs read permission for confidential flag
     
     def test_filter_no_config(self):
         """Test filtering when no config exists"""
@@ -186,7 +215,7 @@ class TicketQueryFilteringTest(TestCase):
         
         try:
             queryset = Ticket.objects.all()
-            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+            filtered = Ticket.get_queryset(queryset, self.user_limited)
             # Should return all when no config
             self.assertEqual(queryset.count(), filtered.count())
         finally:
@@ -207,12 +236,12 @@ class TicketQueryFilteringTest(TestCase):
         
         try:
             queryset = Ticket.objects.all()
-            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_mixed)
+            filtered = Ticket.get_queryset(queryset, self.user_mixed)
             
             ticket_ids = list(filtered.values_list('id', flat=True))
-            # User has 127004 which allows sensitive flag
+            # User has read permission for sensitive flag
             self.assertIn(mixed_ticket.id, ticket_ids)
-            # But not confidential flag (needs 127006)
+            # But not for confidential flag
             self.assertNotIn(self.tickets['confidential'].id, ticket_ids)
         finally:
             mixed_ticket.delete(username=self.user_mixed.username)
@@ -225,7 +254,7 @@ class TicketQueryFilteringTest(TestCase):
                 'public_category',
                 {
                     'name': 'parent',
-                    'permissions': ['127002'],
+                    'permissions': ['read', 'create'],
                     'children': ['child1', 'child2']
                 }
             ],
@@ -234,7 +263,11 @@ class TicketQueryFilteringTest(TestCase):
         
         # Process config
         TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__process_unified_flags(config)
         TicketConfig._TicketConfig__load_config(config)
+        
+        # Generate rights for the new configuration
+        self._generate_test_rights()
         
         # Create hierarchical tickets
         parent_ticket = Ticket(title='Parent', category='parent', resolution='5,0')
@@ -244,10 +277,9 @@ class TicketQueryFilteringTest(TestCase):
         
         try:
             queryset = Ticket.objects.all()
-            filtered = GrievanceAccessControl.filter_ticket_queryset(queryset, self.user_limited)
+            filtered = Ticket.get_queryset(queryset, self.user_limited)
             
             ticket_ids = list(filtered.values_list('id', flat=True))
-            # User doesn't have 127002, shouldn't see parent or child
             self.assertNotIn(parent_ticket.id, ticket_ids)
             self.assertNotIn(child_ticket.id, ticket_ids)
         finally:

--- a/grievance_social_protection/tests/test_ticket_query_filtering.py
+++ b/grievance_social_protection/tests/test_ticket_query_filtering.py
@@ -4,23 +4,29 @@ from core.test_helpers import create_test_interactive_user
 from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, get_rights, collect_all_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, get_rights, collect_all_rights,
 )
 
 
 class TicketQueryFilteringTest(TestCase):
     """Test ticket queryset filtering based on permissions"""
 
+    _config_snapshot = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._setup_test_config()
+        cls._config_snapshot = cls._setup_test_config()
         cls._create_test_users()
         cls._create_test_tickets()
 
     def setUp(self):
         # Reset config for each test
-        self._setup_test_config()
+        self._per_test_snapshot = self._setup_test_config()
+
+    def tearDown(self):
+        restore_grievance_config(self._per_test_snapshot)
 
     @classmethod
     def _setup_test_config(cls):
@@ -50,7 +56,7 @@ class TicketQueryFilteringTest(TestCase):
                 }
             ]
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     @classmethod
     def _create_test_users(cls):
@@ -118,6 +124,8 @@ class TicketQueryFilteringTest(TestCase):
         """Clean up test data"""
         ticket_ids = [t.id for t in cls.tickets.values()]
         Ticket.objects.filter(id__in=ticket_ids).delete()
+        if cls._config_snapshot:
+            restore_grievance_config(cls._config_snapshot)
         super().tearDownClass()
 
     def test_filter_all_permissions(self):
@@ -197,7 +205,7 @@ class TicketQueryFilteringTest(TestCase):
 
         parent_ticket = Ticket(title='Parent', category='parent', resolution='5,0')
         parent_ticket.save(user=self.user_limited)
-        child_ticket = Ticket(title='Child', category='parent|child1', resolution='5,0')
+        child_ticket = Ticket(title='Child', category='parent > child1', resolution='5,0')
         child_ticket.save(user=self.user_limited)
 
         try:

--- a/grievance_social_protection/tests/test_ticket_query_filtering.py
+++ b/grievance_social_protection/tests/test_ticket_query_filtering.py
@@ -131,7 +131,7 @@ class TicketQueryFilteringTest(TestCase):
 
         for name, ticket in self.tickets.items():
             self.assertIn(ticket.id, ticket_ids,
-                         f"Admin user should see '{name}' ticket (category={ticket.category}, flags={ticket.flags})")
+                          f"Admin user should see '{name}' ticket (category={ticket.category}, flags={ticket.flags})")
 
     def test_filter_limited_permissions(self):
         """Test filtering with limited permissions"""

--- a/grievance_social_protection/tests/test_ticket_service_permissions.py
+++ b/grievance_social_protection/tests/test_ticket_service_permissions.py
@@ -1,0 +1,278 @@
+import json
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from core.test_helpers import LogInHelper, create_test_interactive_user
+from core.models import Role, RoleRight, UserRole
+from grievance_social_protection.services import TicketService
+from grievance_social_protection.apps import TicketConfig
+from grievance_social_protection.models import Ticket
+
+
+class TicketServicePermissionsTest(TestCase):
+    """Test permission-based access control in TicketService"""
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_test_config()
+        cls._create_test_users()
+    
+    def setUp(self):
+        # Reset processed data before each test
+        TicketConfig.processed_categories = {}
+        TicketConfig.processed_flags = {}
+        self._setup_test_config()
+    
+    @classmethod
+    def _setup_test_config(cls):
+        """Set up test configuration"""
+        config = {
+            'grievance_types': [
+                'open_category',
+                {
+                    'name': 'restricted_category',
+                    'priority': 'High',
+                    'permissions': ['127001', '127002'],
+                    'default_flags': ['urgent']
+                }
+            ],
+            'grievance_flags': [
+                'public',
+                {
+                    'name': 'sensitive',
+                    'priority': 'Critical',
+                    'permissions': ['127004', '127005']
+                },
+                {
+                    'name': 'urgent',
+                    'priority': 'High'
+                }
+            ],
+            'resolution_times': '5,0'
+        }
+        
+        # Process configuration
+        TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__process_unified_flags(config)
+        TicketConfig._TicketConfig__load_config(config)
+    
+    @classmethod
+    def _create_test_users(cls):
+        """Create test users with different permission levels"""
+        # User with permissions for restricted category
+        cls.user_with_perms = create_test_interactive_user(username='user_with_perms', roles=[1])
+        cls._add_permissions_to_user(cls.user_with_perms, ['127001', '127002'])
+        
+        # User without permissions
+        cls.user_no_perms = create_test_interactive_user(username='user_no_perms', roles=[1])
+        
+        # User with flag permissions
+        cls.user_flag_perms = create_test_interactive_user(username='user_flag_perms', roles=[1])
+        cls._add_permissions_to_user(cls.user_flag_perms, ['127004', '127005'])
+        
+        # Anonymous-like user (no permissions)
+        cls.user_anon = create_test_interactive_user(username='user_anon', roles=[1])
+    
+    @classmethod
+    def _add_permissions_to_user(cls, user, permission_codes):
+        """Add specific permissions to a user"""
+        if hasattr(user, 'i_user') and user.i_user:
+            # Create a custom role for this user
+            role = Role.objects.create(
+                name=f"TestRole_{user.username}",
+                is_system=0,
+                is_blocked=False,
+                audit_user_id=-1
+            )
+            
+            # Add rights to the role
+            for perm_code in permission_codes:
+                RoleRight.objects.create(
+                    role=role,
+                    right_id=int(perm_code),
+                    audit_user_id=-1
+                )
+            
+            # Assign role to user
+            UserRole.objects.create(
+                user=user.i_user,
+                role=role,
+                audit_user_id=-1
+            )
+    
+    def test_create_with_permissions_allowed(self):
+        """Test ticket creation when user has required permissions"""
+        service = TicketService(self.user_with_perms)
+        
+        obj_data = {
+            'category': 'restricted_category',
+            'title': 'Test with permissions',
+            'resolution': '5,0'
+        }
+        
+        result = service.create(obj_data)
+        
+        # Verify success
+        self.assertTrue(result.get('success', False), f"Creation failed: {result}")
+        self.assertIsNotNone(result.get('data', {}).get('uuid'))
+        
+        # Check ticket was created with correct values
+        ticket = Ticket.objects.get(uuid=result['data']['uuid'])
+        self.assertEqual(ticket.category, 'restricted_category')
+        self.assertEqual(ticket.flags, 'urgent')  # Default flag applied
+        self.assertEqual(ticket.priority, 'High')  # Category priority
+        
+        # Clean up
+        ticket.delete(username=self.user_with_perms.username)
+    
+    def test_create_with_permissions_denied(self):
+        """Test ticket creation fails when user lacks permissions"""
+        service = TicketService(self.user_no_perms)
+        
+        obj_data = {
+            'category': 'restricted_category',
+            'title': 'Test without permissions',
+            'resolution': '5,0'
+        }
+        
+        # Service converts PermissionDenied to ValidationError
+        with self.assertRaises(ValidationError) as cm:
+            service.create(obj_data)
+        
+        self.assertIn('restricted_category', str(cm.exception))
+    
+    def test_flag_permissions(self):
+        """Test flag permission checking"""
+        # User without sensitive flag permissions
+        service = TicketService(self.user_no_perms)
+        
+        obj_data = {
+            'category': 'open_category',
+            'title': 'Test flag permissions',
+            'flags': 'public sensitive',
+            'resolution': '5,0'
+        }
+        
+        # Should raise ValidationError for sensitive flag
+        with self.assertRaises(ValidationError) as cm:
+            service.create(obj_data)
+        
+        self.assertIn('sensitive', str(cm.exception))
+        
+        # User with flag permissions should succeed
+        service_with_flag_perms = TicketService(self.user_flag_perms)
+        result = service_with_flag_perms.create(obj_data)
+        
+        self.assertTrue(result.get('success', False))
+        if result.get('success'):
+            ticket = Ticket.objects.get(uuid=result['data']['uuid'])
+            self.assertIn('sensitive', ticket.flags)
+            ticket.delete(username=self.user_flag_perms.username)
+    
+    def test_open_category_no_permissions_required(self):
+        """Test that open categories don't require permissions"""
+        # User with no special permissions
+        service = TicketService(self.user_no_perms)
+        
+        obj_data = {
+            'category': 'open_category',
+            'title': 'Test open category',
+            'resolution': '5,0'
+        }
+        
+        result = service.create(obj_data)
+        
+        # Should succeed
+        self.assertTrue(result.get('success', False), f"Creation failed: {result}")
+        
+        # Clean up
+        if result.get('success'):
+            ticket = Ticket.objects.get(uuid=result['data']['uuid'])
+            ticket.delete(username=self.user_no_perms.username)
+    
+    def test_anonymous_user_behavior(self):
+        """Test behavior with user having no permissions"""
+        # Create a mock anonymous user by setting is_anonymous
+        class AnonymousLikeUser:
+            def __init__(self, base_user):
+                self.base_user = base_user
+                self.is_anonymous = True
+                
+            def __getattr__(self, name):
+                return getattr(self.base_user, name)
+        
+        anon_user = AnonymousLikeUser(self.user_anon)
+        service = TicketService(anon_user)
+        
+        obj_data = {
+            'category': 'open_category',
+            'title': 'Test anonymous',
+            'resolution': '5,0'
+        }
+        
+        with self.assertRaises(ValidationError) as cm:
+            service.create(obj_data)
+        
+        # Check for authentication error
+        error_str = str(cm.exception).lower()
+        self.assertTrue('authentication' in error_str or 'permission' in error_str)
+    
+    def test_category_defaults_applied(self):
+        """Test that category defaults are applied correctly"""
+        user = LogInHelper().get_or_create_user_api()
+        service = TicketService(user)
+        
+        # Test with restricted category (user needs permissions)
+        self._add_permissions_to_user(user, ['127001', '127002'])
+        
+        obj_data = {
+            'category': 'restricted_category',
+            'title': 'Test defaults',
+            'resolution': '5,0'
+        }
+        
+        result = service.create(obj_data)
+        
+        if result.get('success'):
+            ticket = Ticket.objects.get(uuid=result['data']['uuid'])
+            # Should have category defaults
+            self.assertEqual(ticket.priority, 'High')  # From category
+            self.assertEqual(ticket.flags, 'urgent')  # Default flag
+            ticket.delete(username=user.username)
+    
+    def test_permission_inheritance(self):
+        """Test that child categories inherit parent permissions"""
+        # Create a new config with hierarchical categories
+        config = {
+            'grievance_types': [
+                'open_category',
+                {
+                    'name': 'parent_cat',
+                    'permissions': ['127003'],
+                    'children': ['child1', 'child2']
+                }
+            ],
+            'grievance_flags': ['urgent'],
+            'resolution_times': '5,0'
+        }
+        
+        # Process config
+        TicketConfig._TicketConfig__process_unified_categories(config)
+        TicketConfig._TicketConfig__process_unified_flags(config)
+        TicketConfig._TicketConfig__load_config(config)
+        
+        # User without parent permission
+        service = TicketService(self.user_no_perms)
+        
+        obj_data = {
+            'category': 'parent_cat|child1',
+            'title': 'Test child category',
+            'resolution': '5,0'
+        }
+        
+        # Should fail - needs parent permission
+        with self.assertRaises(ValidationError) as cm:
+            service.create(obj_data)
+        
+        self.assertIn('parent_cat|child1', str(cm.exception))

--- a/grievance_social_protection/tests/test_ticket_service_permissions.py
+++ b/grievance_social_protection/tests/test_ticket_service_permissions.py
@@ -3,30 +3,39 @@ from django.test import TestCase
 
 from core.test_helpers import LogInHelper, create_test_interactive_user
 from grievance_social_protection.services import TicketService
-from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.tests.test_helpers import (
-    setup_grievance_config, assign_rights_to_user, get_rights,
+    setup_grievance_config, restore_grievance_config,
+    assign_rights_to_user, get_rights,
 )
 
 
 class TicketServicePermissionsTest(TestCase):
     """Test permission-based access control in TicketService"""
 
+    _config_snapshot = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._setup_test_config()
+        cls._config_snapshot = cls._setup_test_config()
         cls._create_test_users()
 
+    @classmethod
+    def tearDownClass(cls):
+        if cls._config_snapshot:
+            restore_grievance_config(cls._config_snapshot)
+        super().tearDownClass()
+
     def setUp(self):
-        TicketConfig.processed_categories = {}
-        TicketConfig.processed_flags = {}
-        self._setup_test_config()
+        self._per_test_snapshot = self._setup_test_config()
+
+    def tearDown(self):
+        restore_grievance_config(self._per_test_snapshot)
 
     @classmethod
     def _setup_test_config(cls):
-        """Set up test configuration"""
+        """Set up test configuration, returns snapshot for restore."""
         cfg = {
             'grievance_types': [
                 'open_category',
@@ -51,7 +60,7 @@ class TicketServicePermissionsTest(TestCase):
             ],
             'resolution_times': '5,0'
         }
-        setup_grievance_config(cfg)
+        return setup_grievance_config(cfg)
 
     @classmethod
     def _create_test_users(cls):
@@ -233,7 +242,7 @@ class TicketServicePermissionsTest(TestCase):
         service = TicketService(self.user_no_perms)
 
         obj_data = {
-            'category': 'parent_cat|child1',
+            'category': 'parent_cat > child1',
             'title': 'Test child category',
             'resolution': '5,0'
         }
@@ -241,4 +250,4 @@ class TicketServicePermissionsTest(TestCase):
         with self.assertRaises(ValidationError) as cm:
             service.create(obj_data)
 
-        self.assertIn('parent_cat|child1', str(cm.exception))
+        self.assertIn('parent_cat > child1', str(cm.exception))

--- a/grievance_social_protection/tests/test_ticket_service_permissions.py
+++ b/grievance_social_protection/tests/test_ticket_service_permissions.py
@@ -1,33 +1,33 @@
-import json
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from core.test_helpers import LogInHelper, create_test_interactive_user
-from core.models import Role, RoleRight, UserRole
 from grievance_social_protection.services import TicketService
 from grievance_social_protection.apps import TicketConfig
 from grievance_social_protection.models import Ticket
+from grievance_social_protection.tests.test_helpers import (
+    setup_grievance_config, assign_rights_to_user, get_rights,
+)
 
 
 class TicketServicePermissionsTest(TestCase):
     """Test permission-based access control in TicketService"""
-    
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._setup_test_config()
         cls._create_test_users()
-    
+
     def setUp(self):
-        # Reset processed data before each test
         TicketConfig.processed_categories = {}
         TicketConfig.processed_flags = {}
         self._setup_test_config()
-    
+
     @classmethod
     def _setup_test_config(cls):
         """Set up test configuration"""
-        config = {
+        cfg = {
             'grievance_types': [
                 'open_category',
                 {
@@ -51,229 +51,172 @@ class TicketServicePermissionsTest(TestCase):
             ],
             'resolution_times': '5,0'
         }
-        
-        # Process configuration
-        TicketConfig._TicketConfig__process_unified_categories(config)
-        TicketConfig._TicketConfig__process_unified_flags(config)
-        TicketConfig._TicketConfig__load_config(config)
-        
-        # Generate rights for the configuration
-        cls._generate_test_rights()
-    
-    @classmethod
-    def _generate_test_rights(cls):
-        """Use the actual GrievanceRightsManager to generate rights"""
-        from grievance_social_protection.rights import GrievanceRightsManager
-        
-        # Generate rights using the real rights manager
-        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
-    
+        setup_grievance_config(cfg)
+
     @classmethod
     def _create_test_users(cls):
         """Create test users with different permission levels"""
         # User with permissions for restricted category
         cls.user_with_perms = create_test_interactive_user(username='user_with_perms', roles=[1])
-        restricted_rights = TicketConfig.processed_categories.get('restricted_category', {}).get('generated_rights', {})
+        cat_rights = get_rights('processed_categories', 'restricted_category')
         perms = []
-        if restricted_rights.get('read'):
-            perms.append(str(restricted_rights['read']))
-        if restricted_rights.get('create'):
-            perms.append(str(restricted_rights['create']))
-        cls._add_permissions_to_user(cls.user_with_perms, perms)
-        
+        if cat_rights.get('read'):
+            perms.append(cat_rights['read'])
+        if cat_rights.get('create'):
+            perms.append(cat_rights['create'])
+        assign_rights_to_user(cls.user_with_perms, perms, 'SPWithPermsRole')
+
         # User without permissions
         cls.user_no_perms = create_test_interactive_user(username='user_no_perms', roles=[1])
-        
+
         # User with flag permissions
         cls.user_flag_perms = create_test_interactive_user(username='user_flag_perms', roles=[1])
-        sensitive_rights = TicketConfig.processed_flags.get('sensitive', {}).get('generated_rights', {})
+        flag_rights = get_rights('processed_flags', 'sensitive')
         flag_perms = []
-        if sensitive_rights.get('read'):
-            flag_perms.append(str(sensitive_rights['read']))
-        if sensitive_rights.get('create'):
-            flag_perms.append(str(sensitive_rights['create']))
-        cls._add_permissions_to_user(cls.user_flag_perms, flag_perms)
-        
+        if flag_rights.get('read'):
+            flag_perms.append(flag_rights['read'])
+        if flag_rights.get('create'):
+            flag_perms.append(flag_rights['create'])
+        assign_rights_to_user(cls.user_flag_perms, flag_perms, 'SPFlagPermsRole')
+
         # Anonymous-like user (no permissions)
         cls.user_anon = create_test_interactive_user(username='user_anon', roles=[1])
-    
-    @classmethod
-    def _add_permissions_to_user(cls, user, permission_codes):
-        """Add specific permissions to a user"""
-        if hasattr(user, 'i_user') and user.i_user:
-            # Create a custom role for this user
-            role = Role.objects.create(
-                name=f"TestRole_{user.username}",
-                is_system=0,
-                is_blocked=False,
-                audit_user_id=-1
-            )
-            
-            # Add rights to the role
-            for perm_code in permission_codes:
-                RoleRight.objects.create(
-                    role=role,
-                    right_id=int(perm_code),
-                    audit_user_id=-1
-                )
-            
-            # Assign role to user
-            UserRole.objects.create(
-                user=user.i_user,
-                role=role,
-                audit_user_id=-1
-            )
-    
+
     def test_create_with_permissions_allowed(self):
         """Test ticket creation when user has required permissions"""
         service = TicketService(self.user_with_perms)
-        
+
         obj_data = {
             'category': 'restricted_category',
             'title': 'Test with permissions',
             'resolution': '5,0'
         }
-        
+
         result = service.create(obj_data)
-        
-        # Verify success
+
         self.assertTrue(result.get('success', False), f"Creation failed: {result}")
         self.assertIsNotNone(result.get('data', {}).get('uuid'))
-        
-        # Check ticket was created with correct values
+
         ticket = Ticket.objects.get(uuid=result['data']['uuid'])
         self.assertEqual(ticket.category, 'restricted_category')
         self.assertEqual(ticket.flags, 'urgent')  # Default flag applied
         self.assertEqual(ticket.priority, 'High')  # Category priority
-        
-        # Clean up
+
         ticket.delete(username=self.user_with_perms.username)
-    
+
     def test_create_with_permissions_denied(self):
         """Test ticket creation fails when user lacks permissions"""
         service = TicketService(self.user_no_perms)
-        
+
         obj_data = {
             'category': 'restricted_category',
             'title': 'Test without permissions',
             'resolution': '5,0'
         }
-        
-        # Service converts PermissionDenied to ValidationError
+
         with self.assertRaises(ValidationError) as cm:
             service.create(obj_data)
-        
+
         self.assertIn('restricted_category', str(cm.exception))
-    
+
     def test_flag_permissions(self):
         """Test flag permission checking"""
-        # User without sensitive flag permissions
         service = TicketService(self.user_no_perms)
-        
+
         obj_data = {
             'category': 'open_category',
             'title': 'Test flag permissions',
             'flags': 'public sensitive',
             'resolution': '5,0'
         }
-        
-        # Should raise ValidationError for sensitive flag
+
         with self.assertRaises(ValidationError) as cm:
             service.create(obj_data)
-        
+
         self.assertIn('sensitive', str(cm.exception))
-        
+
         # User with flag permissions should succeed
         service_with_flag_perms = TicketService(self.user_flag_perms)
         result = service_with_flag_perms.create(obj_data)
-        
+
         self.assertTrue(result.get('success', False))
         if result.get('success'):
             ticket = Ticket.objects.get(uuid=result['data']['uuid'])
             self.assertIn('sensitive', ticket.flags)
             ticket.delete(username=self.user_flag_perms.username)
-    
+
     def test_open_category_no_permissions_required(self):
         """Test that open categories don't require permissions"""
-        # User with no special permissions
         service = TicketService(self.user_no_perms)
-        
+
         obj_data = {
             'category': 'open_category',
             'title': 'Test open category',
             'resolution': '5,0'
         }
-        
+
         result = service.create(obj_data)
-        
-        # Should succeed
         self.assertTrue(result.get('success', False), f"Creation failed: {result}")
-        
-        # Clean up
+
         if result.get('success'):
             ticket = Ticket.objects.get(uuid=result['data']['uuid'])
             ticket.delete(username=self.user_no_perms.username)
-    
+
     def test_anonymous_user_behavior(self):
         """Test behavior with user having no permissions"""
-        # Create a mock anonymous user by setting is_anonymous
         class AnonymousLikeUser:
             def __init__(self, base_user):
                 self.base_user = base_user
                 self.is_anonymous = True
-                
+
             def __getattr__(self, name):
                 return getattr(self.base_user, name)
-        
+
         anon_user = AnonymousLikeUser(self.user_anon)
         service = TicketService(anon_user)
-        
+
         obj_data = {
             'category': 'open_category',
             'title': 'Test anonymous',
             'resolution': '5,0'
         }
-        
+
         with self.assertRaises(ValidationError) as cm:
             service.create(obj_data)
-        
-        # Check for authentication error
+
         error_str = str(cm.exception).lower()
         self.assertTrue('authentication' in error_str or 'permission' in error_str)
-    
+
     def test_category_defaults_applied(self):
         """Test that category defaults are applied correctly"""
         user = LogInHelper().get_or_create_user_api()
         service = TicketService(user)
-        
-        # Test with restricted category (user needs permissions)
-        restricted_rights = TicketConfig.processed_categories.get('restricted_category', {}).get('generated_rights', {})
+
+        cat_rights = get_rights('processed_categories', 'restricted_category')
         perms = []
-        if restricted_rights.get('read'):
-            perms.append(str(restricted_rights['read']))
-        if restricted_rights.get('create'):
-            perms.append(str(restricted_rights['create']))
-        self._add_permissions_to_user(user, perms)
-        
+        if cat_rights.get('read'):
+            perms.append(cat_rights['read'])
+        if cat_rights.get('create'):
+            perms.append(cat_rights['create'])
+        assign_rights_to_user(user, perms, 'SPDefaultsRole')
+
         obj_data = {
             'category': 'restricted_category',
             'title': 'Test defaults',
             'resolution': '5,0'
         }
-        
+
         result = service.create(obj_data)
-        
+
         if result.get('success'):
             ticket = Ticket.objects.get(uuid=result['data']['uuid'])
-            # Should have category defaults
-            self.assertEqual(ticket.priority, 'High')  # From category
-            self.assertEqual(ticket.flags, 'urgent')  # Default flag
+            self.assertEqual(ticket.priority, 'High')
+            self.assertEqual(ticket.flags, 'urgent')
             ticket.delete(username=user.username)
-    
+
     def test_permission_inheritance(self):
         """Test that child categories inherit parent permissions"""
-        # Create a new config with hierarchical categories
-        config = {
+        cfg = {
             'grievance_types': [
                 'open_category',
                 {
@@ -285,26 +228,17 @@ class TicketServicePermissionsTest(TestCase):
             'grievance_flags': ['urgent'],
             'resolution_times': '5,0'
         }
-        
-        # Process config
-        TicketConfig._TicketConfig__process_unified_categories(config)
-        TicketConfig._TicketConfig__process_unified_flags(config)
-        TicketConfig._TicketConfig__load_config(config)
-        
-        # Generate rights for the new configuration
-        self._generate_test_rights()
-        
-        # User without parent permission
+        setup_grievance_config(cfg)
+
         service = TicketService(self.user_no_perms)
-        
+
         obj_data = {
             'category': 'parent_cat|child1',
             'title': 'Test child category',
             'resolution': '5,0'
         }
-        
-        # Should fail - needs parent permission
+
         with self.assertRaises(ValidationError) as cm:
             service.create(obj_data)
-        
+
         self.assertIn('parent_cat|child1', str(cm.exception))

--- a/grievance_social_protection/tests/test_ticket_service_permissions.py
+++ b/grievance_social_protection/tests/test_ticket_service_permissions.py
@@ -33,7 +33,7 @@ class TicketServicePermissionsTest(TestCase):
                 {
                     'name': 'restricted_category',
                     'priority': 'High',
-                    'permissions': ['127001', '127002'],
+                    'permissions': ['read', 'create'],
                     'default_flags': ['urgent']
                 }
             ],
@@ -42,7 +42,7 @@ class TicketServicePermissionsTest(TestCase):
                 {
                     'name': 'sensitive',
                     'priority': 'Critical',
-                    'permissions': ['127004', '127005']
+                    'permissions': ['read', 'create']
                 },
                 {
                     'name': 'urgent',
@@ -56,20 +56,43 @@ class TicketServicePermissionsTest(TestCase):
         TicketConfig._TicketConfig__process_unified_categories(config)
         TicketConfig._TicketConfig__process_unified_flags(config)
         TicketConfig._TicketConfig__load_config(config)
+        
+        # Generate rights for the configuration
+        cls._generate_test_rights()
+    
+    @classmethod
+    def _generate_test_rights(cls):
+        """Use the actual GrievanceRightsManager to generate rights"""
+        from grievance_social_protection.rights import GrievanceRightsManager
+        
+        # Generate rights using the real rights manager
+        GrievanceRightsManager.generate_automatic_rights(TicketConfig)
     
     @classmethod
     def _create_test_users(cls):
         """Create test users with different permission levels"""
         # User with permissions for restricted category
         cls.user_with_perms = create_test_interactive_user(username='user_with_perms', roles=[1])
-        cls._add_permissions_to_user(cls.user_with_perms, ['127001', '127002'])
+        restricted_rights = TicketConfig.processed_categories.get('restricted_category', {}).get('generated_rights', {})
+        perms = []
+        if restricted_rights.get('read'):
+            perms.append(str(restricted_rights['read']))
+        if restricted_rights.get('create'):
+            perms.append(str(restricted_rights['create']))
+        cls._add_permissions_to_user(cls.user_with_perms, perms)
         
         # User without permissions
         cls.user_no_perms = create_test_interactive_user(username='user_no_perms', roles=[1])
         
         # User with flag permissions
         cls.user_flag_perms = create_test_interactive_user(username='user_flag_perms', roles=[1])
-        cls._add_permissions_to_user(cls.user_flag_perms, ['127004', '127005'])
+        sensitive_rights = TicketConfig.processed_flags.get('sensitive', {}).get('generated_rights', {})
+        flag_perms = []
+        if sensitive_rights.get('read'):
+            flag_perms.append(str(sensitive_rights['read']))
+        if sensitive_rights.get('create'):
+            flag_perms.append(str(sensitive_rights['create']))
+        cls._add_permissions_to_user(cls.user_flag_perms, flag_perms)
         
         # Anonymous-like user (no permissions)
         cls.user_anon = create_test_interactive_user(username='user_anon', roles=[1])
@@ -224,7 +247,13 @@ class TicketServicePermissionsTest(TestCase):
         service = TicketService(user)
         
         # Test with restricted category (user needs permissions)
-        self._add_permissions_to_user(user, ['127001', '127002'])
+        restricted_rights = TicketConfig.processed_categories.get('restricted_category', {}).get('generated_rights', {})
+        perms = []
+        if restricted_rights.get('read'):
+            perms.append(str(restricted_rights['read']))
+        if restricted_rights.get('create'):
+            perms.append(str(restricted_rights['create']))
+        self._add_permissions_to_user(user, perms)
         
         obj_data = {
             'category': 'restricted_category',
@@ -249,7 +278,7 @@ class TicketServicePermissionsTest(TestCase):
                 'open_category',
                 {
                     'name': 'parent_cat',
-                    'permissions': ['127003'],
+                    'permissions': ['read', 'create'],
                     'children': ['child1', 'child2']
                 }
             ],
@@ -261,6 +290,9 @@ class TicketServicePermissionsTest(TestCase):
         TicketConfig._TicketConfig__process_unified_categories(config)
         TicketConfig._TicketConfig__process_unified_flags(config)
         TicketConfig._TicketConfig__load_config(config)
+        
+        # Generate rights for the new configuration
+        self._generate_test_rights()
         
         # User without parent permission
         service = TicketService(self.user_no_perms)

--- a/grievance_social_protection/urls.py
+++ b/grievance_social_protection/urls.py
@@ -1,7 +1,3 @@
-from django.urls import path
-from . import views
-
 urlpatterns = [
-
     # path('attach/', views.attach, name='attach')
 ]


### PR DESCRIPTION
## Summary
Enhances the grievance module with fine-grained access control at category/flag level and adds support for category-specific resolution times.

## Key Features
- **Permission-based access control**: Restrict categories/flags using permission
- **Category resolution times**: Define resolution times per category with inheritance
- **Hierarchical categories**: Support parent-child category relationships
- **Automatic filtering**: Ticket queries automatically filtered by user permissions
- **Unified configuration**: Support both simple strings and enhanced objects in config

## Configuration Example
```json
{
  "grievance_types": [{
    "name": "complaint",
    "permissions": ["127001", "127002"],
    "resolution_times": "3,0",
    "children": [{
      "name": "urgent",
      "resolution_times": "1,0"
    }]
  }]
}
```
## Backward Compatibility
Fully backward compatible - existing configurations continue to work unchanged
