### PR TITLE
Validate default flags are among the known flags

### DIFF
--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -128,16 +128,16 @@ class TicketConfig(AppConfig):
         self.__validate_grievance_dict_fields(cfg, 'default_resolution')
         self.__validate_grievance_default_resolution_time(cfg)
 
-    def _parse_config(self, instance):
+    def _merge_with_defaults(self, instance):
         return {**copy.deepcopy(DEFAULT_CFG), **instance._cfg}
 
     def _validate_module_config(self, instance):
-        cfg = self._parse_config(instance)
+        cfg = self._merge_with_defaults(instance)
         self.__process_config(cfg)
         self.__validate_config(cfg)
 
     def _reload_module_config(self, instance):
-        cfg = self._parse_config(instance)
+        cfg = self._merge_with_defaults(instance)
         self.__process_config(cfg)
         self.__load_config(cfg)
 

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -241,9 +241,6 @@ class TicketConfig(AppConfig):
         references a flag defined in grievance_flags.
         """
         grievance_flags = cfg.get('grievance_flags', [])
-        if not grievance_flags:
-            return
-
         processed_categories = cfg.get('processed_categories', {})
         for category_name, category_info in processed_categories.items():
             for flag in category_info.get('default_flags', []):

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -231,7 +231,7 @@ class TicketConfig(AppConfig):
         if not (0 <= days < 99 and 0 <= hours < 24):
             raise ValidationError(
                 f"Invalid resolution time values for {context}. "
-                "Days must be between 0 and 99, and hours must be between 0 and 24."
+                "Days must be 0-98 and hours must be 0-23."
             )
 
     @classmethod

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -1,4 +1,4 @@
-import json
+import copy
 import logging
 import sys
 import os
@@ -129,8 +129,7 @@ class TicketConfig(AppConfig):
         self.__validate_grievance_default_resolution_time(cfg)
 
     def _parse_config(self, instance):
-        db_config = json.loads(instance.config)
-        return {**DEFAULT_CFG, **db_config}
+        return {**copy.deepcopy(DEFAULT_CFG), **instance._cfg}
 
     def _validate_module_config(self, instance):
         cfg = self._parse_config(instance)

--- a/grievance_social_protection/apps.py
+++ b/grievance_social_protection/apps.py
@@ -1,9 +1,11 @@
+import json
 import logging
 import sys
 import os
 
 from django.apps import AppConfig
 from django.db import OperationalError, ProgrammingError
+from django.core.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -95,14 +97,13 @@ class TicketConfig(AppConfig):
 
     def ready(self):
         from core.models import ModuleConfiguration
+        from core.module_config_registry import register_validator, register_reloader
+
         cfg = ModuleConfiguration.get_or_default(MODULE_NAME, DEFAULT_CFG)
-        self.__process_unified_categories(cfg)
-        self.__process_unified_flags(cfg)
-        self.__validate_grievance_dict_fields(cfg, 'default_responses')
-        self.__validate_grievance_dict_fields(cfg, 'grievance_anonymized_fields')
-        self.__validate_grievance_dict_fields(cfg, 'default_resolution')
-        self.__validate_grievance_default_resolution_time(cfg)
+        self.__process_config(cfg)
+        self.__validate_config(cfg)
         self.__load_config(cfg)
+
         # Generate rights only when the database is available and ready.
         # Skip during migrations, when NO_DATABASE is set, or when
         # core tables (django_content_type, auth_permission) don't exist yet.
@@ -112,6 +113,34 @@ class TicketConfig(AppConfig):
                 GrievanceRightsManager.generate_automatic_rights(TicketConfig)
             except (OperationalError, ProgrammingError):
                 logger.info("Database tables not ready, skipping automatic rights generation.")
+
+        register_validator(MODULE_NAME, self._validate_module_config)
+        register_reloader(MODULE_NAME, self._reload_module_config)
+
+    def __process_config(self, cfg):
+        self.__process_unified_categories(cfg)
+        self.__process_unified_flags(cfg)
+
+    def __validate_config(self, cfg):
+        self.__validate_category_default_flags(cfg)
+        self.__validate_grievance_dict_fields(cfg, 'default_responses')
+        self.__validate_grievance_dict_fields(cfg, 'grievance_anonymized_fields')
+        self.__validate_grievance_dict_fields(cfg, 'default_resolution')
+        self.__validate_grievance_default_resolution_time(cfg)
+
+    def _parse_config(self, instance):
+        db_config = json.loads(instance.config)
+        return {**DEFAULT_CFG, **db_config}
+
+    def _validate_module_config(self, instance):
+        cfg = self._parse_config(instance)
+        self.__process_config(cfg)
+        self.__validate_config(cfg)
+
+    def _reload_module_config(self, instance):
+        cfg = self._parse_config(instance)
+        self.__process_config(cfg)
+        self.__load_config(cfg)
 
     @classmethod
     def __validate_grievance_dict_fields(cls, cfg, field_name):
@@ -151,7 +180,7 @@ class TicketConfig(AppConfig):
             for key in dict_field:
                 value = dict_field[key]
                 if value in ['', None]:
-                    raise ValueError(
+                    raise ValidationError(
                         f"'{key}' in 'default_resolution' has no value. "
                         f"Expected format: 'days,hours' (e.g. '{DEFAULT_TIME_RESOLUTION}')."
                     )
@@ -183,14 +212,8 @@ class TicketConfig(AppConfig):
 
     @classmethod
     def __validate_resolution_time_format(cls, value, context=""):
-        """
-        Validate a single resolution time format.
-
-        Raises:
-            ValueError: If the resolution time format is invalid.
-        """
         if ',' not in value:
-            raise ValueError(
+            raise ValidationError(
                 f"Invalid resolution time format for {context}. "
                 "Configuration should contain two integers representing days and hours, "
                 "separated by a comma."
@@ -200,19 +223,37 @@ class TicketConfig(AppConfig):
             parts = value.split(',')
             days = int(parts[0])
             hours = int(parts[1])
-
-            if not (0 <= days < 99 and 0 <= hours < 24):
-                raise ValueError(
-                    f"Invalid resolution time values for {context}. "
-                    "Days must be between 0 and 99, and hours must be between 0 and 24."
-                )
-        except (ValueError, IndexError) as e:
-            if isinstance(e, ValueError) and "Invalid resolution time" in str(e):
-                raise
-            raise ValueError(
+        except (ValueError, IndexError):
+            raise ValidationError(
                 f"Invalid resolution time format for {context}. "
                 "Expected format: 'days,hours' where both are integers."
             )
+
+        if not (0 <= days < 99 and 0 <= hours < 24):
+            raise ValidationError(
+                f"Invalid resolution time values for {context}. "
+                "Days must be between 0 and 99, and hours must be between 0 and 24."
+            )
+
+    @classmethod
+    def __validate_category_default_flags(cls, cfg):
+        """
+        Validate that every default_flags entry in grievance_types
+        references a flag defined in grievance_flags.
+        """
+        grievance_flags = cfg.get('grievance_flags', [])
+        if not grievance_flags:
+            return
+
+        processed_categories = cfg.get('processed_categories', {})
+        for category_name, category_info in processed_categories.items():
+            for flag in category_info.get('default_flags', []):
+                if flag not in grievance_flags:
+                    raise ValidationError(
+                        f"Category '{category_name}' references default flag '{flag}' "
+                        f"which is not defined in grievance_flags. "
+                        f"Available flags: {grievance_flags}"
+                    )
 
     @classmethod
     def __process_unified_categories(cls, cfg):
@@ -270,7 +311,7 @@ class TicketConfig(AppConfig):
                 # Enhanced dict format with permissions
                 cat_name = item.get('name')
                 if not cat_name:
-                    raise ValueError("Each category dict in 'grievance_types' must have a 'name' field.")
+                    raise ValidationError("Each category dict in 'grievance_types' must have a 'name' field.")
 
                 full_name = f"{parent_name}{CATEGORY_SEPARATOR}{cat_name}" if parent_name else cat_name
 
@@ -278,7 +319,7 @@ class TicketConfig(AppConfig):
                 permissions = list(item.get('permissions', parent.get('permissions', [])))
                 invalid = set(permissions) - VALID_PERMISSION_TYPES
                 if invalid:
-                    raise ValueError(
+                    raise ValidationError(
                         f"Category '{cat_name}' has invalid permission types: {invalid}. "
                         f"Allowed: {sorted(VALID_PERMISSION_TYPES)}"
                     )
@@ -303,7 +344,7 @@ class TicketConfig(AppConfig):
                         # Check if child tries to expose fields hidden by parent
                         invalid_fields = child_visible - parent_visible
                         if invalid_fields:
-                            raise ValueError(
+                            raise ValidationError(
                                 f"Category '{cat_name}' cannot make fields {invalid_fields} visible — "
                                 f"they are not in parent '{parent_name}' visible_fields."
                             )
@@ -379,13 +420,13 @@ class TicketConfig(AppConfig):
                 # Enhanced dict format with permissions
                 flag_name = flag.get('name')
                 if not flag_name:
-                    raise ValueError("Each flag dict in 'grievance_flags' must have a 'name' field.")
+                    raise ValidationError("Each flag dict in 'grievance_flags' must have a 'name' field.")
 
                 # Process permissions
                 permissions = flag.get('permissions', [])
                 invalid = set(permissions) - VALID_PERMISSION_TYPES
                 if invalid:
-                    raise ValueError(
+                    raise ValidationError(
                         f"Flag '{flag_name}' has invalid permission types: {invalid}. "
                         f"Allowed: {sorted(VALID_PERMISSION_TYPES)}"
                     )

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -1,5 +1,9 @@
+import json
+
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
+from core.models import ModuleConfiguration
 from grievance_social_protection.apps import TicketConfig
 
 
@@ -210,3 +214,102 @@ class ConfigProcessingTest(TestCase):
         unified = cfg.get('unified_resolution_times', {})
         self.assertEqual(unified['priority_cat'], '2,0')  # Category-specific wins
         self.assertEqual(unified['legacy_cat'], '4,0')    # From default_resolution
+
+    def test_category_default_flags_must_exist_in_grievance_flags(self):
+        """Regression: saving config where a category references an undefined default flag must fail"""
+        invalid_config = {
+            "grievance_types": [
+                {
+                    "name": "complaint",
+                    "default_flags": ["urgent"]
+                }
+            ],
+            "grievance_flags": ["sensitive"]
+        }
+
+        mc = ModuleConfiguration(
+            module="grievance_social_protection",
+            layer="be",
+            version="1.0.0",
+            config=json.dumps(invalid_config),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            mc.save()
+
+        self.assertIn('urgent', str(ctx.exception))
+        self.assertIn('complaint', str(ctx.exception))
+
+    def test_category_default_flags_valid_config_saves(self):
+        """Saving config where default_flags are all defined in grievance_flags should succeed"""
+        valid_config = {
+            "grievance_types": [
+                {
+                    "name": "complaint",
+                    "default_flags": ["urgent"]
+                }
+            ],
+            "grievance_flags": ["urgent", "sensitive"]
+        }
+
+        mc = ModuleConfiguration(
+            module="grievance_social_protection",
+            layer="be",
+            version="1.0.0",
+            config=json.dumps(valid_config),
+        )
+        mc.save()
+        self.assertIsNotNone(mc.pk)
+        mc.delete()
+
+    def test_nested_category_inherited_default_flags_must_exist(self):
+        """Regression: inherited default_flags from parent categories must also be validated on save"""
+        invalid_config = {
+            "grievance_types": [
+                {
+                    "name": "parent",
+                    "default_flags": ["nonexistent"],
+                    "children": ["child"]
+                }
+            ],
+            "grievance_flags": ["other_flag"]
+        }
+
+        mc = ModuleConfiguration(
+            module="grievance_social_protection",
+            layer="be",
+            version="1.0.0",
+            config=json.dumps(invalid_config),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            mc.save()
+
+        self.assertIn('nonexistent', str(ctx.exception))
+
+    def test_admin_form_rejects_invalid_config(self):
+        """Regression: admin form should display validation error inline, not save"""
+        from django.contrib.admin.sites import AdminSite
+        from django.contrib.admin.options import ModelAdmin
+
+        invalid_config = {
+            "grievance_types": [
+                {
+                    "name": "complaint",
+                    "default_flags": ["urgent"]
+                }
+            ],
+            "grievance_flags": ["sensitive"]
+        }
+
+        admin = ModelAdmin(ModuleConfiguration, AdminSite())
+        Form = admin.get_form(request=None)
+        form = Form(data={
+            'module': 'grievance_social_protection',
+            'layer': 'be',
+            'version': '1.0.0',
+            'config': json.dumps(invalid_config),
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('urgent', str(form.errors))

--- a/grievance_social_protection/tests/test_config_processing.py
+++ b/grievance_social_protection/tests/test_config_processing.py
@@ -216,7 +216,7 @@ class ConfigProcessingTest(TestCase):
         self.assertEqual(unified['legacy_cat'], '4,0')    # From default_resolution
 
     def test_category_default_flags_must_exist_in_grievance_flags(self):
-        """Regression: saving config where a category references an undefined default flag must fail"""
+        """Saving config where a category references an undefined default flag must fail"""
         invalid_config = {
             "grievance_types": [
                 {
@@ -263,7 +263,7 @@ class ConfigProcessingTest(TestCase):
         mc.delete()
 
     def test_nested_category_inherited_default_flags_must_exist(self):
-        """Regression: inherited default_flags from parent categories must also be validated on save"""
+        """Inherited default_flags from parent categories must also be validated on save"""
         invalid_config = {
             "grievance_types": [
                 {
@@ -286,6 +286,31 @@ class ConfigProcessingTest(TestCase):
             mc.save()
 
         self.assertIn('nonexistent', str(ctx.exception))
+
+    def test_default_flags_with_no_grievance_flags_configured(self):
+        """default_flags on a category with no grievance_flags configured must fail"""
+        invalid_config = {
+            "grievance_types": [
+                {
+                    "name": "complaint",
+                    "default_flags": ["urgent"]
+                }
+            ],
+            "grievance_flags": []
+        }
+
+        mc = ModuleConfiguration(
+            module="grievance_social_protection",
+            layer="be",
+            version="1.0.0",
+            config=json.dumps(invalid_config),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            mc.save()
+
+        self.assertIn('urgent', str(ctx.exception))
+        self.assertIn('complaint', str(ctx.exception))
 
     def test_admin_form_rejects_invalid_config(self):
         """Regression: admin form should display validation error inline, not save"""

--- a/grievance_social_protection/tests/test_gql_ticket_create.py
+++ b/grievance_social_protection/tests/test_gql_ticket_create.py
@@ -1,10 +1,14 @@
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
+from grievance_social_protection.apps import DEFAULT_CFG
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.schema import Query, Mutation
 from grievance_social_protection.tests.gql_payloads import gql_mutation_create_ticket
-from grievance_social_protection.tests.test_helpers import create_test_grievance_user
+from grievance_social_protection.tests.test_helpers import (
+    create_test_grievance_user,
+    setup_grievance_config,
+)
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 
 
@@ -23,6 +27,7 @@ class GQLTicketCreateTestCase(openIMISGraphQLTestCase):
     @classmethod
     def setUpClass(cls):
         super(GQLTicketCreateTestCase, cls).setUpClass()
+        setup_grievance_config(dict(DEFAULT_CFG))
         cls.user = create_test_grievance_user(username='user_authorized')
 
         gql_schema = Schema(

--- a/grievance_social_protection/tests/test_gql_ticket_create.py
+++ b/grievance_social_protection/tests/test_gql_ticket_create.py
@@ -27,7 +27,7 @@ class GQLTicketCreateTestCase(openIMISGraphQLTestCase):
     @classmethod
     def setUpClass(cls):
         super(GQLTicketCreateTestCase, cls).setUpClass()
-        setup_grievance_config(dict(DEFAULT_CFG))
+        setup_grievance_config(DEFAULT_CFG)
         cls.user = create_test_grievance_user(username='user_authorized')
 
         gql_schema = Schema(

--- a/grievance_social_protection/tests/test_gql_ticket_update.py
+++ b/grievance_social_protection/tests/test_gql_ticket_update.py
@@ -1,10 +1,15 @@
 from core.models import MutationLog
 from graphene import Schema
 from graphene.test import Client
+from grievance_social_protection.apps import DEFAULT_CFG
 from grievance_social_protection.models import Ticket
 from grievance_social_protection.schema import Query, Mutation
 from grievance_social_protection.tests.gql_payloads import gql_mutation_update_ticket
-from grievance_social_protection.tests.test_helpers import create_ticket, create_test_grievance_user
+from grievance_social_protection.tests.test_helpers import (
+    create_ticket,
+    create_test_grievance_user,
+    setup_grievance_config,
+)
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 
 
@@ -25,6 +30,7 @@ class GQLTicketUpdateTestCase(openIMISGraphQLTestCase):
     @classmethod
     def setUpClass(cls):
         super(GQLTicketUpdateTestCase, cls).setUpClass()
+        setup_grievance_config(dict(DEFAULT_CFG))
         cls.user = create_test_grievance_user(username='user_authorized')
         cls.existing_ticket = create_ticket(cls.user)
 

--- a/grievance_social_protection/tests/test_gql_ticket_update.py
+++ b/grievance_social_protection/tests/test_gql_ticket_update.py
@@ -30,7 +30,7 @@ class GQLTicketUpdateTestCase(openIMISGraphQLTestCase):
     @classmethod
     def setUpClass(cls):
         super(GQLTicketUpdateTestCase, cls).setUpClass()
-        setup_grievance_config(dict(DEFAULT_CFG))
+        setup_grievance_config(DEFAULT_CFG)
         cls.user = create_test_grievance_user(username='user_authorized')
         cls.existing_ticket = create_ticket(cls.user)
 

--- a/grievance_social_protection/tests/test_helpers.py
+++ b/grievance_social_protection/tests/test_helpers.py
@@ -1,3 +1,5 @@
+import copy
+
 from core.models import Role, RoleRight, UserRole
 from core.test_helpers import create_test_interactive_user, create_test_role
 from grievance_social_protection.apps import TicketConfig
@@ -69,6 +71,7 @@ def setup_grievance_config(cfg):
     Returns:
         dict: Snapshot of previous state (pass to restore_grievance_config).
     """
+    cfg = copy.deepcopy(cfg)
     snapshot = save_grievance_config()
     TicketConfig._TicketConfig__process_unified_categories(cfg)
     TicketConfig._TicketConfig__process_unified_flags(cfg)

--- a/grievance_social_protection/tests/ticket_service_test.py
+++ b/grievance_social_protection/tests/ticket_service_test.py
@@ -10,7 +10,11 @@ from grievance_social_protection.tests.data import (
     service_add_ticket_payload_bad_resolution_hour,
     service_update_ticket_payload
 )
-from grievance_social_protection.tests.test_helpers import create_ticket
+from grievance_social_protection.apps import DEFAULT_CFG
+from grievance_social_protection.tests.test_helpers import (
+    create_ticket,
+    setup_grievance_config,
+)
 from core.test_helpers import LogInHelper
 from django.utils.translation import gettext as _
 
@@ -24,6 +28,7 @@ class TicketServiceTest(TestCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        setup_grievance_config(dict(DEFAULT_CFG))
         cls.user = LogInHelper().get_or_create_user_api()
         cls.service = TicketService(cls.user)
         cls.query_all = Ticket.objects.filter(is_deleted=False)

--- a/grievance_social_protection/tests/ticket_service_test.py
+++ b/grievance_social_protection/tests/ticket_service_test.py
@@ -28,7 +28,7 @@ class TicketServiceTest(TestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        setup_grievance_config(dict(DEFAULT_CFG))
+        setup_grievance_config(DEFAULT_CFG)
         cls.user = LogInHelper().get_or_create_user_api()
         cls.service = TicketService(cls.user)
         cls.query_all = Ticket.objects.filter(is_deleted=False)


### PR DESCRIPTION
# Description

Add default flags validation and also register validations & reload. This surfaces config this class of config error early i.e. at config time. Without this change the error only surfaces at grievance ticket creation time.

This PR depends on https://github.com/openimis/openimis-be-core_py/pull/426, Module CI will fail until the upstream PR is merged. Then we will need to re-trigger Module CI test run.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires https://github.com/openimis/openimis-be-core_py/pull/426
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Before:
<img width="1600" height="1046" alt="image" src="https://github.com/user-attachments/assets/874d6173-9518-433c-9ce5-4749caaf14b8" />

After:
<img width="1072" height="1162" alt="image" src="https://github.com/user-attachments/assets/da53fb13-118c-4587-a030-83e5a3cb84f4" />


## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
